### PR TITLE
Add script to generate monolithic fw binary

### DIFF
--- a/libraries/WiFi/extra/combine.py
+++ b/libraries/WiFi/extra/combine.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import sys;
+
+booloaderData = open("bootloader.bin", "rb").read()
+partitionData = open("partition-table.bin", "rb").read()
+networkData = open("network_adapter.bin", "rb").read()
+
+# 0x0 bootloader.bin 0x8000 partition-table.bin 0x10000 network_adapter.bin
+
+
+# calculate the output binary size, app offset 
+outputSize = 0x10000 + len(networkData)
+if (outputSize % 1024):
+	outputSize += 1024 - (outputSize % 1024)
+
+# allocate and init to 0xff
+outputData = bytearray(b'\xff') * outputSize
+
+# copy data: bootloader, partitions, app
+for i in range(0, len(booloaderData)):
+	outputData[0x0000 + i] = booloaderData[i]
+
+for i in range(0, len(partitionData)):
+	outputData[0x8000 + i] = partitionData[i]
+
+for i in range(0, len(networkData)):
+	outputData[0x10000 + i] = networkData[i]
+
+
+outputFilename = "ESP32-C3.bin"
+if (len(sys.argv) > 1):
+	outputFilename = sys.argv[1]
+
+# write out
+with open(outputFilename,"w+b") as f:
+	f.seek(0)
+	f.write(outputData)


### PR DESCRIPTION
Add combine script to make a monolithic binary that can be flashed at 0x0.
This produces `ESP32-C3.bin` file (a different name can be specified as parameter).
The script has all the offset from [here](https://github.com/bcmi-labs/ArduinoCore-renesas/blob/main/libraries/WiFi/extra/flasher.sh) and seems to work fine when flashed on a C33 with `$ espflash write-bin -p /dev/ttyACM1 -b 230400 0x0 ESP32-C3.bin` (version of espflash 2.0.0). 
It's based on https://github.com/arduino/nina-fw/blob/master/combine.py