### PR TITLE
Configure permissions of `GITHUB_TOKEN` in workflows

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   compile-test:
     runs-on: ubuntu-latest
+    permissions: {}
 
     env:
       # sketch paths to compile (recursive) for all boards

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Comment size deltas reports to PRs

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -55,6 +57,7 @@ jobs:
   download:
     needs: check
     runs-on: ubuntu-latest
+    permissions: {}
 
     strategy:
       matrix:
@@ -81,6 +84,9 @@ jobs:
   sync:
     needs: download
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Set environment variables


### PR DESCRIPTION
[`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) is an access token provided automatically by GitHub Actions. The default permissions of this token for workflow runs in a trusted context (i.e., not triggered by a PR from a fork) are set in the [enterprise](https://docs.github.com/en/enterprise-cloud@latest/admin/policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#enforcing-a-policy-for-workflow-permissions-in-your-enterprise)/[organization](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#setting-the-permissions-of-the-github_token-for-your-organization)/[repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)'s administrative settings, giving it either read-only or write permissions in all scopes.

In the case of a read-only default configuration, any workflow operations that require write permissions would fail with an error like:

https://github.com/arduino/ArduinoCore-renesas/actions/runs/5354302514/jobs/9711176308#step:9:46

```text
403: Resource not accessible by integration
```

https://github.com/arduino/ArduinoCore-renesas/actions/runs/5354680503/jobs/9712023980#step:3:7

```text
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
Traceback (most recent call last):
  File "/reportsizedeltas/reportsizedeltas.py", line [7](https://github.com/arduino/ArduinoCore-renesas/actions/runs/5354680503/jobs/9712023980#step:3:8)[9](https://github.com/arduino/ArduinoCore-renesas/actions/runs/5354680503/jobs/9712023980#step:3:10)7, in <module>
    main()  # pragma: no cover
    ^^^^^^
  File "/reportsizedeltas/reportsizedeltas.py", line 32, in main
    report_size_deltas.report_size_deltas()
  File "/reportsizedeltas/reportsizedeltas.py", line 96, in report_size_deltas
    self.report_size_deltas_from_workflow_artifacts()
  File "/reportsizedeltas/reportsizedeltas.py", line [16](https://github.com/arduino/ArduinoCore-renesas/actions/runs/5354680503/jobs/9712023980#step:3:17)2, in report_size_deltas_from_workflow_artifacts
    self.comment_report(pr_number=pr_number, report_markdown=report)
  File "/reportsizedeltas/reportsizedeltas.py", line 537, in comment_report
    self.http_request(url=url, data=report_data)
  File "/reportsizedeltas/reportsizedeltas.py", line 601, in http_request
    with self.raw_http_request(url=url, data=data) as response_object:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/reportsizedeltas/reportsizedeltas.py", line 636, in raw_http_request
    raise TimeoutError("Maximum number of URL load retries exceeded")
TimeoutError: Maximum number of URL load retries exceeded
```

In the case of a write default configuration, workflows have unnecessary permissions, which violates the security [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).

For this reason, GitHub Actions now allows [fine grained control of the permissions provided to the token](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs), which are used here to configure the workflows for only the permissions they require in each job.

The [automatic permissions downgrade](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) from write to read for workflows triggered by events generated by a PR from a fork is unaffected.

Even when all permissions are withheld (`permissions: {}`), the token still provides [the authenticated API request rate limiting allowance](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions), which is a common use of the token in these workflows.

Read permissions are required in [the `contents` scope](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview) in order to [checkout](https://github.com/actions/checkout) private repositories. Even though those permissions are not required for this public repository, the standardized "**Sync Labels**" workflow template is intended to be applicable in public and private repositories both and so a small excess in permissions was chosen in order to use [the upstream template](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md) unmodified.

---

Here are demonstration runs in my fork of the workflows with the changes proposed here:

- https://github.com/per1234/ArduinoCore-renesas/actions/runs/5358792927 (and the report: https://github.com/per1234/ArduinoCore-renesas/pull/1#issuecomment-1604570997)
- https://github.com/per1234/ArduinoCore-renesas/actions/runs/5358866455/jobs/9721735775#step:9:44
- https://github.com/per1234/ArduinoCore-renesas/actions/runs/5358866452