### PR TITLE
Update action dependencies of GitHub Actions workflows

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -95,7 +95,7 @@ jobs:
 
       # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
       - name: Checkout ArduinoCore-API
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: arduino/ArduinoCore-API
           path: extras/ArduinoCore-API
@@ -110,7 +110,7 @@ jobs:
         if: steps.checkapi.outputs.IS_API == 'true'
 
       - name: Checkout Basic examples
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: arduino/arduino-examples
           path: examples
@@ -163,7 +163,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save memory usage change report as artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: sketches-reports
           path: sketches-reports

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Download JSON schema for labels configuration file
         id: download-schema
-        uses: carlosperate/download-file-action@v1
+        uses: carlosperate/download-file-action@v2
         with:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
           location: ${{ runner.temp }}/label-configuration-schema
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Download
-        uses: carlosperate/download-file-action@v1
+        uses: carlosperate/download-file-action@v2
         with:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
 
@@ -114,7 +114,7 @@ jobs:
           path: ${{ env.CONFIGURATIONS_FOLDER }}
 
       - name: Remove unneeded artifact
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ env.CONFIGURATIONS_ARTIFACT }}
 


### PR DESCRIPTION
The repository's GitHub Actions workflows use several GitHub Actions actions. The steps that use the actions [pin the dependency to a major version series](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-release-management-for-actions). This means the specific dependency version is unmanaged within that major version series, but the reference must be updated after there is a new major version release of the dependency.

Several of the dependencies were pinned to outdated major version refs, causing the workflows to miss the benefits of recent development work on those dependencies. They are hereby updated to the latest major version refs. The breaking changes that caused the major version bumps in the dependencies are not relevant to our usage of them so no additional adjustments are needed in order to perform these bumps.