### PR TITLE
Pin sketch compilation actions to major version refs

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -122,7 +122,7 @@ jobs:
         run: tree extras/
 
       - name: Compile examples
-        uses: arduino/compile-sketches@main
+        uses: arduino/compile-sketches@v1
         with:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -10,4 +10,4 @@ jobs:
 
     steps:
       - name: Comment size deltas reports to PRs
-        uses: arduino/report-size-deltas@main
+        uses: arduino/report-size-deltas@v1


### PR DESCRIPTION
Previously, the development versions of Arduino's sketch compilation actions were used in the project's GitHub Actions workflows. Using release versions of the actions instead provides a more stable CI system.

Use of the major version ref will cause the workflow to benefit from ongoing development to the action up until such time as a new major release is made, at which time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before updating the major ref (e.g., `uses: arduino/compile-sketches@v1` -> `uses: arduino/compile-sketches@v2`).