### PR TITLE
Fix SPI mode and bit order settings

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -383,7 +383,7 @@ void ArduinoSPI::configSpi(arduino::SPISettings const & settings)
   spcmd0 |= (uint32_t) bit_order << 12;
 
   /* Configure the Bit Rate Division Setting */
-  spcmd0 &= !(((uint32_t)0xFF) << 2);
+  spcmd0 &= ~(((uint32_t)0xFF) << 2);
   spcmd0 |= (uint32_t) spck_div.brdv << 2;
 
   /* Update settings. */

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -383,7 +383,7 @@ void ArduinoSPI::configSpi(arduino::SPISettings const & settings)
   spcmd0 |= (uint32_t) bit_order << 12;
 
   /* Configure the Bit Rate Division Setting */
-  spcmd0 &= ~(((uint32_t)0xFF) << 2);
+  spcmd0 &= ~(((uint32_t) 3) << 2);
   spcmd0 |= (uint32_t) spck_div.brdv << 2;
 
   /* Update settings. */


### PR DESCRIPTION
#12 
The logical not in [this line](https://github.com/arduino/ArduinoCore-renesas/blob/149f78b6490ccbafeb420f68919c381a5bdb6e21/libraries/SPI/SPI.cpp#L386C38-L386C38) makes the mask 0 and wipes out the earlier settings. This should be a bitwise not, but even so the `0xFF` would also mask off the SSLA bits b6-b4 and half of the SPB bits b9-b8. Changing `0xFF` to `3` will clear just the BRDV bits b3-b2.