### PR TITLE
Update RTC_Alarm.ino

### DIFF
--- a/libraries/RTC/examples/RTC_Alarm/RTC_Alarm.ino
+++ b/libraries/RTC/examples/RTC_Alarm/RTC_Alarm.ino
@@ -1,33 +1,28 @@
 /*
  * This example demonstrates how to use the alarm functionality of the RTC
- * (Real Time Clock) on the Portenta C33.
+ * (Real Time Clock) on the Portenta C33 and UNO R4 Minima / WiFi.
  *
- * It switches the built-in LED between blue and red each time the alarm
+ * It turns on the built-in LED when the alarm
  * is triggered, which is once every minute in this example.
+ * In addition, inside the loop, we print the state of the alarm
+ * continuously, which is either 0 (LOW) or 1 (HIGH).
  *
+ * Note that the Portenta C33's LED is inverted and will be lit when
+ * the state is 0 (LOW).
  */
+
+unsigned long previousMillis = 0;
+const long interval = 1000;
+bool ledState = false;
 
 #include "RTC.h"
 
-void alarmCallback()
-{
-  static bool ledState = false;
-  if (!ledState) {
-    digitalWrite(LEDB, HIGH);
-    digitalWrite(LEDR, LOW);
-  }
-  else {
-    digitalWrite(LEDR, HIGH);
-    digitalWrite(LEDB, LOW);
-  }
-  ledState = !ledState;
-}
-
 void setup() {
-  pinMode(LEDR, OUTPUT);
-  pinMode(LEDB, OUTPUT);
-  digitalWrite(LEDR, HIGH);
-  digitalWrite(LEDB, LOW);
+  //initialize Serial Communication
+  Serial.begin(9600);
+
+  //define LED as output
+  pinMode(LED_BUILTIN, OUTPUT);
 
   // Initialize the RTC
   RTC.begin();
@@ -44,9 +39,31 @@ void setup() {
   // Make sure to only match on the seconds in this example - not on any other parts of the date/time
   AlarmMatch matchTime;
   matchTime.addMatchSecond();
-  
+
+  //sets the alarm callback
   RTC.setAlarmCallback(alarmCallback, alarmTime, matchTime);
 }
 
 void loop() {
+
+  // in the loop, we continuously print the alarm's current state
+  // this is for debugging only and has no effect on the alarm whatsoever
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval) {
+    // save the last time you blinked the LED
+    previousMillis = currentMillis;
+    Serial.print("Alarm state: ");
+    Serial.println(ledState);
+  }
+}
+
+// this function activates every minute
+// and changes the ledState boolean
+void alarmCallback() {
+  if (!ledState) {
+    digitalWrite(LED_BUILTIN, HIGH);
+  } else {
+    digitalWrite(LED_BUILTIN, LOW);
+  }
+  ledState = !ledState;
 }


### PR DESCRIPTION
Update RTC_Alarm to work with UNO R4 Minima & WiFi boards.

Changes made.
- Switch the LED used (from RGB > LED_BUILTIN). R4 boards have no RGB so this example does not compile/work.
- Made `ledState` global so that it can be used in `loop()` as well.
- Added serial functions to the loop to print the current state of the alarm. Alarm state is now printed each second.
- Moved `alarmCallback()` function to the bottom for better readability.

Example is tested and verified on both UNO R4 boards and the Portenta C33. 