### PR TITLE
fix for compatibility SSL

### DIFF
--- a/libraries/WiFiS3/src/WiFiS3.h
+++ b/libraries/WiFiS3/src/WiFiS3.h
@@ -24,5 +24,6 @@
 #include "WiFiClient.h"
 #include "WiFiServer.h"
 #include "WiFiUdp.h"
+#include "WiFiSSLClient.h"
 
 #endif


### PR DESCRIPTION
ciao @tigoe can you use this pull request to check the compatibility with the wifiNINA:SSLclient examples?

Basically just including this and testing the usage of WiFISSLclient i notice that when and end point is public them works