### PR TITLE
LED_matrix: move _sequenceDone = true out of if block

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -175,8 +175,8 @@ public:
             }
             if(_callBack != nullptr){
                 _callBack();
-                _sequenceDone = true;
             }
+            _sequenceDone = true;
         }
         memcpy(framebuffer, (uint32_t*)frame, sizeof(frame));
     }


### PR DESCRIPTION
Currently if you write a sketch that relies on knowing when a sequence completes, by having your code call sequenceDone(), this will only work if your sketch sets a non-null callback function, as the code that sets the condition is currently in the if block:
```
if(_callBack != nullptr){
```
Simply moved the line to after the if block