### PR TITLE
Bugfix: `micros()` returns smaller number when timer wraps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ libraries/Storage/.development
 cores/arduino/mydebug.cpp.donotuse
 .DS_Store
 .DS_Store?
+/.vs
+/.gitignore

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -2,8 +2,10 @@
 #include "IRQManager.h"
 #include "FspTimer.h"
 
+// this file implements the following public funcions: delay, delayMicroseconds, yield, millis, micros
+// The millis and micros implementation uses timer AGT0 (24 HMz, 16-bits, count-down mode, 1 ms period)
+
 volatile unsigned long agt_time_ms = 0;
-uint32_t _freq_hz = 0;
 
 __attribute__((weak)) void delay(uint32_t ms) {
 	R_BSP_SoftwareDelay(ms, BSP_DELAY_UNITS_MILLISECONDS);
@@ -17,20 +19,24 @@ __attribute__((weak)) void yield() {
 }
 
 static FspTimer main_timer;
-
-static uint32_t _top_counter;
+// specifying these details as constants makes micros() faster !
+#define _timer_type           AGT_TIMER
+#define _timer_index          0
+#define _timer_underflow_bit  R_AGT0->AGTCR_b.TUNDF
+#define _timer_clock_divider  TIMER_SOURCE_DIV_8 // dividers 1, 2, 4 and 8 work because _timer_period is < 16-bit. bug in R4 1.0.2: divider 4 acts as 1 !? 
+#define _timer_clock_freq     24000000UL
+#define _timer_ticks_per_us   (_timer_clock_freq / ((1 << _timer_clock_divider) * 1000000UL))
+#define _timer_period         (_timer_ticks_per_us * 1000UL)
 
 static void timer_micros_callback(timer_callback_args_t __attribute((unused)) *p_args) {
-	agt_time_ms += 1; //1ms
+	agt_time_ms += 1;
 }
 
 void startAgt() {
-	main_timer.begin(TIMER_MODE_PERIODIC, AGT_TIMER, 0, 2000.0f, 0.5f, timer_micros_callback);
-	IRQManager::getInstance().addPeripheral(IRQ_AGT,(void*)main_timer.get_cfg());
+	main_timer.begin(TIMER_MODE_PERIODIC, _timer_type, _timer_index, _timer_period, 1, _timer_clock_divider, timer_micros_callback);;
+	main_timer.setup_overflow_irq();
 	main_timer.open();
-	_top_counter = main_timer.get_counter();
-	main_timer.start();
-	_freq_hz = main_timer.get_freq_hz();
+	main_timer.start(); // bug in R4 1.0.2: calling start() is not necessary: open() starts the counter already !?
 }
 
 unsigned long millis()
@@ -43,10 +49,11 @@ unsigned long millis()
 }
 
 unsigned long micros() {
-
-	// Convert time to us
+	// Return time in us
 	NVIC_DisableIRQ(main_timer.get_cfg()->cycle_end_irq);
-	uint32_t time_us = ((main_timer.get_period_raw() - main_timer.get_counter()) * 1000 / main_timer.get_period_raw()) +  (agt_time_ms * 1000);
+	uint32_t ms = agt_time_ms;
+	uint32_t cnt = main_timer.get_counter();
+	if (_timer_underflow_bit && (cnt > (_timer_period / 2))) ++ms; // the counter wrapped arround just before it was read
 	NVIC_EnableIRQ(main_timer.get_cfg()->cycle_end_irq);
-	return time_us;
+	return  ms * 1000 + (((_timer_period - 1) - cnt) / _timer_ticks_per_us);
 }

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -28,8 +28,8 @@ void startAgt() {
 	// in 1 ms (period) is an integer number and below the 16-bit counter limit
 	// on the Uno R4 the AGT clock is 24 MHz / 8 -> 3000 ticks per ms
 	// on the Portenta C33 the AGT clock is 50 Mhz / 8 -> 6250 ticks per ms
-	const uint32_t clock_freq = R_FSP_SystemClockHzGet(FSP_PRIV_CLOCK_PCLKB);
-	const uint32_t period = clock_freq / ((1 << TIMER_SOURCE_DIV_8) * 1000UL);
+	const uint32_t clock_freq_Hz = R_FSP_SystemClockHzGet(FSP_PRIV_CLOCK_PCLKB);
+	const uint32_t period = clock_freq_Hz / ((1 << TIMER_SOURCE_DIV_8) * 1000UL);
 	agt_timer.begin(TIMER_MODE_PERIODIC, AGT_TIMER, 0, period, 1, TIMER_SOURCE_DIV_8, timer_micros_callback);;
 	agt_timer.setup_overflow_irq(8);
 	agt_timer.open();

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -27,6 +27,7 @@ static FspTimer main_timer;
 #define _timer_clock_freq     24000000UL
 #define _timer_ticks_per_us   (_timer_clock_freq / ((1 << _timer_clock_divider) * 1000000UL))
 #define _timer_period         (_timer_ticks_per_us * 1000UL)
+#define TIMER_PRIORITY        8
 
 static void timer_micros_callback(timer_callback_args_t __attribute((unused)) *p_args) {
 	agt_time_ms += 1;
@@ -34,7 +35,7 @@ static void timer_micros_callback(timer_callback_args_t __attribute((unused)) *p
 
 void startAgt() {
 	main_timer.begin(TIMER_MODE_PERIODIC, _timer_type, _timer_index, _timer_period, 1, _timer_clock_divider, timer_micros_callback);;
-	main_timer.setup_overflow_irq();
+	main_timer.setup_overflow_irq(TIMER_PRIORITY);
 	main_timer.open();
 	main_timer.start(); // bug in R4 1.0.2: calling start() is not necessary: open() starts the counter already !?
 }

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -56,7 +56,7 @@ unsigned long micros() {
 	uint32_t const down_counts = main_timer.get_counter();
 	if (_timer_get_underflow_bit() && (down_counts > (_timer_period / 2)))
 	{
-		// the counter wrapped arround just before it was read
+		// the counter wrapped around just before it was read
 		++ms;
 	}
 	NVIC_EnableIRQ(main_timer.get_cfg()->cycle_end_irq);

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -22,6 +22,7 @@ static FspTimer main_timer;
 const uint8_t _timer_type = AGT_TIMER;
 const uint8_t _timer_index = 0;
 inline uint8_t _timer_get_underflow_bit() { return R_AGT0->AGTCR_b.TUNDF; }
+inline uint16_t _timer_get_counter() { return R_AGT0->AGT; }
 // clock divider 8 works for the Uno R4 and Portenta C33 both because _timer_period is < 16-bit. 
 // on the Uno R4 the AGT clock is 24 MHz / 8 -> 3000 ticks per ms
 // on the Portenta C33 the AGT clock is 50 Mhz / 8 -> 6250 ticks per ms
@@ -55,7 +56,7 @@ unsigned long micros() {
 	// Return time in us
 	NVIC_DisableIRQ(main_timer.get_cfg()->cycle_end_irq);
 	uint32_t ms = agt_time_ms;
-	uint32_t const down_counts = main_timer.get_counter();
+	uint32_t const down_counts = _timer_get_counter();
 	if (_timer_get_underflow_bit() && (down_counts > (_timer_period / 2)))
 	{
 		// the counter wrapped around just before it was read

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -30,7 +30,13 @@ void startAgt() {
 	// on the Portenta C33 the AGT clock is 50 Mhz / 8 -> 6250 ticks per ms
 	const uint32_t clock_freq_Hz = R_FSP_SystemClockHzGet(FSP_PRIV_CLOCK_PCLKB);
 	const uint32_t period = clock_freq_Hz / ((1 << TIMER_SOURCE_DIV_8) * 1000UL);
-	agt_timer.begin(TIMER_MODE_PERIODIC, AGT_TIMER, 0, period, 1, TIMER_SOURCE_DIV_8, timer_micros_callback);;
+	agt_timer.begin(/* mode */ TIMER_MODE_PERIODIC,
+                  /* type */ AGT_TIMER,
+                  /* channel */ 0,
+                  period,
+                  /* pulse */ 1,
+                  TIMER_SOURCE_DIV_8,
+                  timer_micros_callback);;
 	agt_timer.setup_overflow_irq(8);
 	agt_timer.open();
 	agt_timer.start(); // bug in R4 1.0.2: calling start() is not necessary: open() starts the counter already !?

--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -20,16 +20,16 @@ __attribute__((weak)) void yield() {
 
 static FspTimer main_timer;
 // specifying these details as constants makes micros() faster !
-#define _timer_type           AGT_TIMER
-#define _timer_index          0
-#define _timer_underflow_bit  R_AGT0->AGTCR_b.TUNDF
-#define _timer_clock_divider  TIMER_SOURCE_DIV_8 // dividers 1, 2, 4 and 8 work because _timer_period is < 16-bit. bug in R4 1.0.2: divider 4 acts as 1 !? 
-#define _timer_clock_freq     24000000UL
-#define _timer_ticks_per_us   (_timer_clock_freq / ((1 << _timer_clock_divider) * 1000000UL))
-#define _timer_period         (_timer_ticks_per_us * 1000UL)
-#define TIMER_PRIORITY        8
+#define _timer_type                AGT_TIMER
+#define _timer_index               0
+#define _timer_get_underflow_bit() R_AGT0->AGTCR_b.TUNDF
+#define _timer_clock_divider       TIMER_SOURCE_DIV_8 // dividers 1, 2 and 8 work because _timer_period is < 16-bit. the divider 4 seems not supported: acts as 1
+#define _timer_clock_freq          24000000UL
+#define _timer_counts_per_us       (_timer_clock_freq / ((1 << _timer_clock_divider) * 1000000UL))
+#define _timer_period              (_timer_counts_per_us * 1000UL)
+#define TIMER_PRIORITY             8
 
-static void timer_micros_callback(timer_callback_args_t __attribute((unused)) *p_args) {
+static void timer_micros_callback(timer_callback_args_t __attribute((unused))* p_args) {
 	agt_time_ms += 1;
 }
 
@@ -53,8 +53,13 @@ unsigned long micros() {
 	// Return time in us
 	NVIC_DisableIRQ(main_timer.get_cfg()->cycle_end_irq);
 	uint32_t ms = agt_time_ms;
-	uint32_t cnt = main_timer.get_counter();
-	if (_timer_underflow_bit && (cnt > (_timer_period / 2))) ++ms; // the counter wrapped arround just before it was read
+	uint32_t const down_counts = main_timer.get_counter();
+	if (_timer_get_underflow_bit() && (down_counts > (_timer_period / 2)))
+	{
+		// the counter wrapped arround just before it was read
+		++ms;
+	}
 	NVIC_EnableIRQ(main_timer.get_cfg()->cycle_end_irq);
-	return  ms * 1000 + (((_timer_period - 1) - cnt) / _timer_ticks_per_us);
+	uint32_t const up_counts = (_timer_period - 1) - down_counts;
+	return  (ms * 1000) + (up_counts / _timer_counts_per_us);
 }


### PR DESCRIPTION
See [issue 49](https://github.com/arduino/ArduinoCore-renesas/issues/49)
1. Fix for anomaly in micros() when the counter wrapped just before it was read (same solution as in R3 code)
2. Specify timer configuration as constants to make micros() considerably faster