### PR TITLE
Update sineWave example of AnalogWave core library

### DIFF
--- a/libraries/AnalogWave/examples/SineWave/SineWave.ino
+++ b/libraries/AnalogWave/examples/SineWave/SineWave.ino
@@ -6,12 +6,11 @@ int freq = 10;  // in hertz, change accordingly
 
 void setup() {
   Serial.begin(115200);
-  pinMode(A0, INPUT);
   wave.sine(freq);
 }
 
 void loop() {
-  freq = map(analogRead(A0), 0, 1024, 0, 10000);
+  freq = map(analogRead(A5), 0, 1024, 0, 10000);
   Serial.println("Frequency is now " + String(freq) + " hz");
   wave.freq(freq);
   delay(1000);


### PR DESCRIPTION
SineWave example of the AnalogWave library was using A0 as an input pin, but the A0 pin is the DAC output pin.
https://forum.arduino.cc/t/invalid-r4-sinewave-ino-example/1149139

This PR changes the potentiometer input pin to A5, to match the other DAC examples in the library.

