### PR TITLE
Remove LED Matrix Live preview sketch comment

### DIFF
--- a/libraries/Arduino_LED_Matrix/examples/LivePreview/LivePreview.ino
+++ b/libraries/Arduino_LED_Matrix/examples/LivePreview/LivePreview.ino
@@ -2,6 +2,8 @@
   This sketch allows live editing of the matrix pixels using WebSerial
   To test, head to https://ledmatrix-editor.arduino.cc
 
+  The LED Matrix editor is part of Arduino Labs (https://labs.arduino.cc/), and is therefore considered experimental software.
+
   Don't forget to close any serial monitor already opened.
 */
 

--- a/libraries/Arduino_LED_Matrix/examples/LivePreview/LivePreview.ino
+++ b/libraries/Arduino_LED_Matrix/examples/LivePreview/LivePreview.ino
@@ -1,7 +1,6 @@
 /*
   This sketch allows live editing of the matrix pixels using WebSerial
   To test, head to https://ledmatrix-editor.arduino.cc
-  press 'p' and select 'UNO R4 WiFi' board from the list.
 
   Don't forget to close any serial monitor already opened.
 */


### PR DESCRIPTION
The removed comment line references an interface element that doesn't exist in the LED Matrix editor anymore.
