### PR TITLE
[Arduino_CAN] support both 11-Bit (standard) and 29-Bit (extended) IDs.

### DIFF
--- a/extras/e2studioProjects/portenta_h33_lib/configuration.xml
+++ b/extras/e2studioProjects/portenta_h33_lib/configuration.xml
@@ -1060,8 +1060,8 @@
       <property id="config.driver.canfd.rxfifo.7.int_threshold" value="enum.driver.canfd.fifo.int_threshold.1_2"/>
       <property id="config.driver.canfd.rxfifo.7.payload" value="enum.driver.canfd.fifo.payload.8"/>
       <property id="config.driver.canfd.rxfifo.7.depth" value="enum.driver.canfd.fifo.depth.16"/>
-      <property id="config.driver.canfd.afl.ch0_num" value="1"/>
-      <property id="config.driver.canfd.afl.ch1_num" value="1"/>
+      <property id="config.driver.canfd.afl.ch0_num" value="2"/>
+      <property id="config.driver.canfd.afl.ch1_num" value="2"/>
     </config>
     <config id="config.driver.gpt">
       <property id="config.driver.gpt.param_checking_enable" value="config.driver.gpt.param_checking_enable.bsp"/>

--- a/libraries/Arduino_CAN/examples/CAN1Write/CAN1Write.ino
+++ b/libraries/Arduino_CAN/examples/CAN1Write/CAN1Write.ino
@@ -54,7 +54,7 @@ void loop()
    */
   uint8_t const msg_data[] = {0xCA,0xFE,0,0,0,0,0,0};
   memcpy((void *)(msg_data + 4), &msg_cnt, sizeof(msg_cnt));
-  CanMsg msg(CAN_ID, sizeof(msg_data), msg_data);
+  CanMsg const msg(CanStandardId(CAN_ID), sizeof(msg_data), msg_data);
 
   /* Transmit the CAN message, capture and display an
    * error core in case of failure.

--- a/libraries/Arduino_CAN/examples/CANWrite/CANWrite.ino
+++ b/libraries/Arduino_CAN/examples/CANWrite/CANWrite.ino
@@ -35,7 +35,7 @@ void loop()
    */
   uint8_t const msg_data[] = {0xCA,0xFE,0,0,0,0,0,0};
   memcpy((void *)(msg_data + 4), &msg_cnt, sizeof(msg_cnt));
-  CanMsg msg(CAN_ID, sizeof(msg_data), msg_data);
+  CanMsg const msg(CanStandardId(CAN_ID), sizeof(msg_data), msg_data);
 
   /* Transmit the CAN message, capture and display an
    * error core in case of failure.

--- a/libraries/Arduino_CAN/keywords.txt
+++ b/libraries/Arduino_CAN/keywords.txt
@@ -10,6 +10,8 @@ CAN	KEYWORD1
 CAN1	KEYWORD1
 CanMsg	KEYWORD1
 CanBitRate	KEYWORD1
+CanStandardId	KEYWORD2
+CanExtendedId	KEYWORD2
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -24,6 +26,11 @@ available	KEYWORD2
 read	KEYWORD2
 isError	KEYWORD2
 clearError	KEYWORD2
+
+getStandardId	KEYWORD2
+getExtendedId	KEYWORD2
+isStandardId	KEYWORD2
+isExtendedId	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
@@ -56,9 +56,9 @@ R7FA4M1_CAN::R7FA4M1_CAN(int const can_tx_pin, int const can_rx_pin)
   CAN_DEFAULT_MASK,
   CAN_DEFAULT_MASK,
   CAN_DEFAULT_MASK,
-  0,                /* Use no id filtering -> a CAN frame with any ID will be stored in receive mailbox #0. */
+  0,                /* Use no id filtering -> a CAN frame with any ID will be stored in receive mailbox group #0. */
   CAN_DEFAULT_MASK,
-  CAN_DEFAULT_MASK,
+  0,                /* Use no id filtering -> a CAN frame with any ID will be stored in receive mailbox group #2. */
   CAN_DEFAULT_MASK
 }
 , _can_mailbox
@@ -74,15 +74,15 @@ R7FA4M1_CAN::R7FA4M1_CAN(int const can_tx_pin, int const can_rx_pin)
   { .mailbox_id =  6, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
   { .mailbox_id =  7, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
   /* Mailbox Group #2 */
-  { .mailbox_id =  8, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
-  { .mailbox_id =  9, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
-  { .mailbox_id = 10, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
-  { .mailbox_id = 11, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id =  8, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id =  9, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id = 10, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id = 11, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
   /* Mailbox Group #3 */
-  { .mailbox_id = 12, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
-  { .mailbox_id = 13, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
-  { .mailbox_id = 14, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
-  { .mailbox_id = 15, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id = 12, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id = 13, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id = 14, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
+  { .mailbox_id = 15, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_TRANSMIT},
   /* We only use the very first receive mailbox for receiving. */
   /* Mailbox Group #4 */
   { .mailbox_id =  0, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
@@ -95,22 +95,22 @@ R7FA4M1_CAN::R7FA4M1_CAN(int const can_tx_pin, int const can_rx_pin)
   { .mailbox_id =  6, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
   { .mailbox_id =  7, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
   /* Mailbox Group #6 */
-  { .mailbox_id =  8, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
-  { .mailbox_id =  9, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
-  { .mailbox_id = 10, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
-  { .mailbox_id = 11, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id =  8, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id =  9, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id = 10, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id = 11, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
   /* Mailbox Group #7 */
-  { .mailbox_id = 12, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
-  { .mailbox_id = 13, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
-  { .mailbox_id = 14, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
-  { .mailbox_id = 15, .id_mode = CAN_ID_MODE_EXTENDED, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE }
+  { .mailbox_id = 12, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id = 13, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id = 14, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE },
+  { .mailbox_id = 15, .id_mode = CAN_ID_MODE_STANDARD, .frame_type = CAN_FRAME_TYPE_DATA, .mailbox_type = CAN_MAILBOX_RECEIVE }
 }
 , _can_extended_cfg
 {
   .clock_source   = CAN_CLOCK_SOURCE_PCLKB,
   .p_mailbox_mask = _can_mailbox_mask,
   .p_mailbox      = _can_mailbox,
-  .global_id_mode = CAN_GLOBAL_ID_MODE_EXTENDED,
+  .global_id_mode = CAN_GLOBAL_ID_MODE_MIXED,
   .mailbox_count  = CAN_MAX_NO_MAILBOXES,
   .message_mode   = CAN_MESSAGE_MODE_OVERWRITE,
   .p_fifo_int_cfg = nullptr,
@@ -205,9 +205,11 @@ int R7FA4M1_CAN::disableInternalLoopback()
 
 int R7FA4M1_CAN::write(CanMsg const & msg)
 {
+  bool const is_standard_id = msg.isStandardId();
+
   can_frame_t can_msg = {
-    /* id               = */ msg.id,
-    /* id_mode          = */ CAN_ID_MODE_EXTENDED,
+    /* id               = */ is_standard_id ? msg.getStandardId()  : msg.getExtendedId(),
+    /* id_mode          = */ is_standard_id ? CAN_ID_MODE_STANDARD : CAN_ID_MODE_EXTENDED,
     /* type             = */ CAN_FRAME_TYPE_DATA,
     /* data_length_code = */ min(msg.data_length, CAN_DATA_BUFFER_LENGTH),
     /* options          = */ 0
@@ -215,7 +217,9 @@ int R7FA4M1_CAN::write(CanMsg const & msg)
 
   memcpy(can_msg.data, msg.data, can_msg.data_length_code);
 
-  if(fsp_err_t const rc = R_CAN_Write(&_can_ctrl, CAN_MAILBOX_ID_0, &can_msg); rc != FSP_SUCCESS)
+  if(fsp_err_t const rc = R_CAN_Write(&_can_ctrl,
+                                      is_standard_id ? CAN_MAILBOX_ID_0 : CAN_MAILBOX_ID_16,
+                                      &can_msg); rc != FSP_SUCCESS)
     return -rc;
 
   return 1;
@@ -241,7 +245,7 @@ void R7FA4M1_CAN::onCanCallback(can_callback_args_t * p_args)
       /* Extract the received CAN message. */
       CanMsg const msg
       (
-        p_args->frame.id,
+        (p_args->frame.id_mode == CAN_ID_MODE_STANDARD) ? CanStandardId(p_args->frame.id) : CanExtendedId(p_args->frame.id),
         p_args->frame.data_length_code,
         p_args->frame.data
       );

--- a/libraries/Arduino_CAN/src/R7FA6M5_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA6M5_CAN.cpp
@@ -190,9 +190,11 @@ int R7FA6M5_CAN::disableInternalLoopback()
 
 int R7FA6M5_CAN::write(CanMsg const & msg)
 {
+  bool const is_standard_id = msg.isStandardId();
+
   can_frame_t can_msg = {
-    /* id               = */ msg.id,
-    /* id_mode          = */ CAN_ID_MODE_EXTENDED,
+    /* id               = */ is_standard_id ? msg.getStandardId()  : msg.getExtendedId(),
+    /* id_mode          = */ is_standard_id ? CAN_ID_MODE_STANDARD : CAN_ID_MODE_EXTENDED,
     /* type             = */ CAN_FRAME_TYPE_DATA,
     /* data_length_code = */ min(msg.data_length, CAN_DATA_BUFFER_LENGTH),
     /* options          = */ 0 /* This ensures that CAN Classic is used. */
@@ -221,7 +223,7 @@ size_t R7FA6M5_CAN::available()
     /* Extract the received CAN message. */
     CanMsg const msg
     (
-      frame.id,
+      (frame.id_mode == CAN_ID_MODE_STANDARD) ? CanStandardId(frame.id) : CanExtendedId(frame.id),
       frame.data_length_code,
       frame.data
     );
@@ -247,7 +249,7 @@ void R7FA6M5_CAN::onCanFDCallback(can_callback_args_t * p_args)
       /* Extract the received CAN message. */
       CanMsg const msg
       (
-        p_args->frame.id,
+        (p_args->frame.id_mode == CAN_ID_MODE_STANDARD) ? CanStandardId(p_args->frame.id) : CanExtendedId(p_args->frame.id),
         p_args->frame.data_length_code,
         p_args->frame.data
       );

--- a/libraries/Arduino_CAN/src/R7FA6M5_CAN_AFL.c
+++ b/libraries/Arduino_CAN/src/R7FA6M5_CAN_AFL.c
@@ -23,6 +23,26 @@ canfd_afl_entry_t const CANFD0_AFL[CANFD_CFG_AFL_CH0_RULE_NUM] = {
         .rx_buffer   = (canfd_rx_mb_t) CANFD_RX_MB_0,
         .fifo_select_flags = CANFD_RX_FIFO_0,
       }
+  },
+  {
+    .id =
+      {
+        .id = 0x1FFFFFFF,
+        .frame_type = CAN_FRAME_TYPE_DATA,
+        .id_mode    = CAN_ID_MODE_STANDARD,
+      },
+    .mask =
+      {
+        .mask_id         = 0,
+        .mask_frame_type = 1,
+        .mask_id_mode    = 1,
+      },
+    .destination =
+      {
+        .minimum_dlc = CANFD_MINIMUM_DLC_0,
+        .rx_buffer   = (canfd_rx_mb_t) CANFD_RX_MB_1,
+        .fifo_select_flags = CANFD_RX_FIFO_1,
+      }
   }
 };
 
@@ -33,6 +53,26 @@ canfd_afl_entry_t const CANFD1_AFL[CANFD_CFG_AFL_CH1_RULE_NUM] = {
         .id = 0x1FFFFFFF,
         .frame_type = CAN_FRAME_TYPE_DATA,
         .id_mode    = CAN_ID_MODE_EXTENDED,
+      },
+    .mask =
+      {
+        .mask_id         = 0,
+        .mask_frame_type = 1,
+        .mask_id_mode    = 1,
+      },
+    .destination =
+      {
+        .minimum_dlc = CANFD_MINIMUM_DLC_0,
+        .rx_buffer   = (canfd_rx_mb_t) CANFD_RX_MB_1,
+        .fifo_select_flags = CANFD_RX_FIFO_1,
+      }
+  },
+    {
+    .id =
+      {
+        .id = 0x1FFFFFFF,
+        .frame_type = CAN_FRAME_TYPE_DATA,
+        .id_mode    = CAN_ID_MODE_STANDARD,
       },
     .mask =
       {

--- a/variants/PORTENTA_C33/includes/ra_cfg/fsp_cfg/r_canfd_cfg.h
+++ b/variants/PORTENTA_C33/includes/ra_cfg/fsp_cfg/r_canfd_cfg.h
@@ -9,8 +9,8 @@
 
 #define CANFD_CFG_PARAM_CHECKING_ENABLE   ((1))
 
-#define CANFD_CFG_AFL_CH0_RULE_NUM   (1)
-#define CANFD_CFG_AFL_CH1_RULE_NUM   (1)
+#define CANFD_CFG_AFL_CH0_RULE_NUM   (2)
+#define CANFD_CFG_AFL_CH1_RULE_NUM   (2)
 
 #define CANFD_CFG_GLOBAL_ERROR_CH    ((1U))
 


### PR DESCRIPTION
This fixes #36.

Requires https://github.com/arduino/ArduinoCore-API/pull/194 .