### PR TITLE
Update tinyusb submodule to track mainline

### DIFF
--- a/libraries/UsbHostMsd/UsbHostMsd.cpp
+++ b/libraries/UsbHostMsd/UsbHostMsd.cpp
@@ -113,16 +113,10 @@ int USBHostMSD::write(const void *buffer, bd_addr_t addr, bd_size_t size) {
         block_number =  addr / block_size;
         count = size / block_size;
 
-        for (uint32_t b = block_number; b < block_number + count; b++) {
-            in_progress = true;
-            if(tuh_msc_write10(usb_host_msd_get_device_address(), get_lun(), buf, b, 1, complete_cb, 0)) {
-                while(in_progress) {
-                    delay(10);
-                }
-                buf += block_size;
-            }
-            else {
-                return -1;
+        in_progress = true;
+        if(tuh_msc_write10(usb_host_msd_get_device_address(), get_lun(), buf, block_number, count, complete_cb, 0)) {
+            while (in_progress) {
+                tuh_task();
             }
         }
         return 0;
@@ -145,16 +139,10 @@ int USBHostMSD::read(void *buffer, bd_addr_t addr, bd_size_t size)
         block_number =  addr / block_size;
         count = size / block_size;
 
-        for (uint32_t b = block_number; b < block_number + count; b++) {
-            in_progress = true;
-            if(tuh_msc_read10(usb_host_msd_get_device_address(), get_lun(), buf, b, 1, complete_cb, 0)) {
-                while(in_progress) {
-                    delay(10);
-                }
-                buf += block_size;
-            }
-            else {
-                return -1;
+        in_progress = true;
+        if(tuh_msc_read10(usb_host_msd_get_device_address(), get_lun(), buf, block_number, count, complete_cb, 0)) {
+            while (in_progress) {
+                tuh_task();
             }
         }
         return 0;

--- a/variants/MINIMA/pins_arduino.h
+++ b/variants/MINIMA/pins_arduino.h
@@ -157,6 +157,8 @@ static const uint8_t SS  =  PIN_SPI_CS;
 #define USB_PID           (0x0069)
 #define USB_NAME          "UNO R4 Minima"
 
+#define VUSB_LDO_ENABLE     1
+
 /* EEPROM DEFINES */
 
 #define ARDUINO_FLASH_TYPE  LP_FLASH

--- a/variants/PORTENTA_C33/tusb_config.h
+++ b/variants/PORTENTA_C33/tusb_config.h
@@ -102,6 +102,11 @@
 #define CFG_TUD_DFU_RUNTIME      1
 
 #define CFG_TUH_MSC              1
+#define CFG_TUH_HUB              1
+#define CFG_TUH_DEVICE_MAX       (3*CFG_TUH_HUB + 1)
+#define CFG_TUH_ENDPOINT_MAX     8
+#define CFG_TUH_API_EDPT_XFER    1
+
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE   ((TUD_OPT_HIGH_SPEED ? 512 : 64) * 8)

--- a/variants/UNOWIFIR4/pins_arduino.h
+++ b/variants/UNOWIFIR4/pins_arduino.h
@@ -159,6 +159,8 @@ static const uint8_t SS  =  PIN_SPI_CS;
 #define USB_PID           (0x006D)
 #define USB_NAME          "UNO R4 WiFi"
 
+#define VUSB_LDO_ENABLE     1
+
 /* EEPROM DEFINES */
 
 #define ARDUINO_FLASH_TYPE  LP_FLASH


### PR DESCRIPTION
Since the patches for USB HS (Portenta C33) have been merged in mainline, we can safely abandon our fork.
Some modifications are required for changed APIs, plus HUB host support has been added for C33