### PR TITLE
Fix undefined behavior in RTC.begin()

### DIFF
--- a/libraries/RTC/src/RTC.cpp
+++ b/libraries/RTC/src/RTC.cpp
@@ -610,6 +610,7 @@ bool RTClock::begin() {
     else {
         is_initialized = false;
     }
+    return is_initialized;
 }
 
 bool RTClock::getTime(RTCTime &t) {


### PR DESCRIPTION
Resolves compilers generating the wrong assembly per https://github.com/arduino/ArduinoCore-renesas/issues/88