### PR TITLE
Simple Bounds checking on APIs like pinMode who use the array g_pin_cfg array

### DIFF
--- a/cores/arduino/analog.cpp
+++ b/cores/arduino/analog.cpp
@@ -799,6 +799,7 @@ void analogWrite(pin_size_t pinNumber, int value)
 
   if(ptr != nullptr) {
     //check the pinmux in case it's been modified by a call to pinMode()
+    if (pinNumber >= (g_pin_cfg_size / sizeof(g_pin_cfg[0]))) return;  /* pinNumber > sizeof of pin table */
     bool has_peripheral_mux = R_PFS->PORT[g_pin_cfg[pinNumber].pin >> IOPORT_PRV_PORT_OFFSET].PIN[g_pin_cfg[pinNumber].pin & BSP_IO_PRV_8BIT_MASK].PmnPFS & IOPORT_CFG_PERIPHERAL_PIN;
     if (!has_peripheral_mux) {
       ptr->end();

--- a/cores/arduino/digital.cpp
+++ b/cores/arduino/digital.cpp
@@ -1,6 +1,7 @@
 #include "Arduino.h"
 
 void pinMode(pin_size_t pin, const PinMode mode) {
+    if (pin >= (g_pin_cfg_size / sizeof(g_pin_cfg[0]))) return;  /* pinNumber > sizeof of pin table */
 	switch (mode) {
 		case INPUT:
 		case INPUT_PULLDOWN: // TODO: document the INPUT_PULLDOWN is unavailable
@@ -19,10 +20,12 @@ void pinMode(pin_size_t pin, const PinMode mode) {
 }
 
 void digitalWrite(pin_size_t pin, PinStatus val) {
+    if (pin >= (g_pin_cfg_size / sizeof(g_pin_cfg[0]))) return;  /* pinNumber > sizeof of pin table */
 	R_IOPORT_PinWrite(NULL, g_pin_cfg[pin].pin, val == LOW ? BSP_IO_LEVEL_LOW : BSP_IO_LEVEL_HIGH);
 }
 
 PinStatus digitalRead(pin_size_t pin) {
+    if (pin >= (g_pin_cfg_size / sizeof(g_pin_cfg[0]))) return LOW;  /* pinNumber > sizeof of pin table */
 	bsp_io_level_t ret;
 	R_IOPORT_PinRead(NULL, g_pin_cfg[pin].pin, &ret);
 	return (ret == BSP_IO_LEVEL_LOW ? LOW : HIGH);


### PR DESCRIPTION
As I mentioned in the forum thread:
https://forum.arduino.cc/t/apis-like-digitalwrite-who-use-g-pinc-cfg-should-do-bounds-checking/1156322

I believe that many of the simple functions should have some form of parameter testing.  For example: pinMode(100, OUTPUT); Should fail instead of trying to use random garbage off the end of the array to pass down to the next level.

Some of the links that @per1234 mentioned on the forum thread, it looks these issues have bounced around for years: 
Like: https://github.com/arduino/ArduinoCore-avr/pull/302

So decided to at least try to do it for a few of the APIs that have this issue.  Most of the other references to this array appear to either check or are driven by pin information in defined in the variant.  Worst case, it is rejected.

