### PR TITLE
Reduce the number of compiler warnings

### DIFF
--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -342,7 +342,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     if(p == IRQ_USB && cfg != NULL) {
         USBIrqCfg_t *irqcfg = (USBIrqCfg_t *)cfg;
 
-        if (irqcfg->first_irq_number != FSP_INVALID_VECTOR) {
+        if (irqcfg->first_irq_number != (uint32_t)FSP_INVALID_VECTOR) {
             // already configured, return
             goto end_config;
         }
@@ -405,7 +405,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     else if(p == IRQ_USB_HS && cfg != NULL) {
         USBIrqCfg_t *irqcfg = (USBIrqCfg_t *)cfg;
 
-        if (irqcfg->first_irq_number != FSP_INVALID_VECTOR) {
+        if (irqcfg->first_irq_number != (uint32_t)FSP_INVALID_VECTOR) {
             // already configured, return
             goto end_config;
         }
@@ -1659,7 +1659,7 @@ void IRQManager::set_can_tx_link_event(int li, int ch)
 #endif
 }
 
-void IRQManager::set_canfd_error_link_event(int li, int ch)
+void IRQManager::set_canfd_error_link_event(__attribute__((unused)) int li, __attribute__((unused)) int ch)
 {
   if (0) {}
 #ifdef ELC_EVENT_CAN0_CHERR
@@ -1674,7 +1674,7 @@ void IRQManager::set_canfd_error_link_event(int li, int ch)
 #endif
 }
 
-void IRQManager::set_canfd_rx_link_event(int li, int ch)
+void IRQManager::set_canfd_rx_link_event(__attribute__((unused)) int li, __attribute__((unused)) int ch)
 {
   if (0) {}
 #ifdef ELC_EVENT_CAN0_COMFRX
@@ -1689,7 +1689,7 @@ void IRQManager::set_canfd_rx_link_event(int li, int ch)
 #endif
 }
 
-void IRQManager::set_canfd_tx_link_event(int li, int ch)
+void IRQManager::set_canfd_tx_link_event(__attribute__((unused)) int li, __attribute__((unused)) int ch)
 {
   if (0) {}
 #ifdef ELC_EVENT_CAN0_TX

--- a/cores/arduino/cm_backtrace/cm_backtrace.c
+++ b/cores/arduino/cm_backtrace/cm_backtrace.c
@@ -117,9 +117,9 @@ static const char * const print_info[] = {
 #endif
 };
 
-static char* fw_name;
-static char* hw_ver;
-static char* sw_ver;
+static const char* fw_name;
+static const char* hw_ver;
+static const char* sw_ver;
 static uint32_t main_stack_start_addr = 0;
 static size_t main_stack_size = 0;
 static uint32_t code_start_addr = 0;


### PR DESCRIPTION
Resolves #77

At least partially.  I did not go into the API class to fix the printf statement issue.

I marked the unused parameters by using __attribute__((unused)) 
I marked some variables to const.
and needed to caste a couple of places that use the FSP_INVALID-
