### PR TITLE
Fix LittleFS formatting freeze bug

### DIFF
--- a/libraries/BlockDevices/SDCardBlockDevice.cpp
+++ b/libraries/BlockDevices/SDCardBlockDevice.cpp
@@ -346,6 +346,8 @@ int SDCardBlockDevice::close() {
    fsp_err_t rv = FSP_ERR_INVALID_ADDRESS;
    rv = R_SDHI_Close (&ctrl);
    opened = false;
+   card_inserted = false;
+   initialized = false;
    return (int)rv;
 }
 


### PR DESCRIPTION
LittleFileSystem::reformat() on the SD Card block device internally runs LittleFileSystem::format() and then LittleFileSystem::mount() in a sequence. After LittleFileSystem::format()'s main job is performed using the LittleFS file system driver one level below it, it runs deinit() on the block device. That leads, after a series of calls, to a call to the Renesas FSP function R_SDHI_Close(), which sets the initialized field of the ctrl structure to false. LittleFileSystem::mount() runs next, and begins by running init() on the block device, but because it's still in a state where card_inserted and initialized are true, full initialization doesn't occur - only parts of it. This leaves the initialized field of the ctrl structure being false, which leads to the FSP-internal function r_sdhi_common_error_check() returning an error when it's called by the FSP function R_SDHI_Read() from SDCardBlockDevice::read(), which is, in turn, called from LittleFileSystem::mount(). This is caught by the LittleFS file system driver function lfs_bd_read() at the layer directly over the SDCardBlockDevice::read() function, which, in turn, sends the board into an infinite loop and the format freezes.