### PR TITLE
Restore and use PINCOUNT_fn() wrapper

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -61,7 +61,6 @@ ioport_peripheral_t getPinConfig(bsp_io_port_pin_t pin);
 extern "C" {
 #endif
 extern const PinMuxCfg_t g_pin_cfg[];
-extern const size_t g_pin_cfg_size;
 #if defined(__cplusplus)
 }
 #endif

--- a/cores/arduino/Interrupts.cpp
+++ b/cores/arduino/Interrupts.cpp
@@ -24,7 +24,6 @@
 #if EXT_INTERRUPTS_HOWMANY > 0
 
 extern const PinMuxCfg_t g_pin_cfg[];
-extern const size_t g_pin_cfg_size;
 
 #define MAX_IRQ_CHANNEL (15)
 
@@ -76,7 +75,7 @@ pin_size_t digitalPinToInterrupt(pin_size_t pin) { return pin; }
 static int pin2IrqChannel(int pin) {
 /* -------------------------------------------------------------------------- */  
   /* verify index are good */
-  if(pin < 0 || pin >= (int)(g_pin_cfg_size / sizeof(g_pin_cfg[0]))) {
+  if(pin < 0 || pin >= PINS_COUNT) {
     return -1;
   }
   /* getting configuration from table */

--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -194,7 +194,7 @@ done:
 /* -------------------------------------------------------------------------- */
 void UART::begin(unsigned long baudrate, uint16_t config) {
 /* -------------------------------------------------------------------------- */  
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
 
   init_ok = cfg_pins(max_index);
   

--- a/cores/arduino/pwm.cpp
+++ b/cores/arduino/pwm.cpp
@@ -2,9 +2,6 @@
 #include "pwm.h"
 #include "bsp_api.h"
 
-extern const PinMuxCfg_t g_pin_cfg[];
-extern const size_t g_pin_cfg_size;
-
 PwmOut::PwmOut(int pinNumber) :
   _pin(pinNumber),
   _enabled(false)
@@ -43,7 +40,7 @@ bool PwmOut::cfg_pin(int max_index) {
 /* default begin function, starts the timers with default pwm configuration (490Hz and 50%) */
 bool PwmOut::begin() {
   bool rv = true;
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
   rv &= cfg_pin(max_index);
 
   if(rv) {
@@ -67,7 +64,7 @@ bool PwmOut::begin() {
 bool PwmOut::begin(uint32_t period_width, uint32_t pulse_width, bool raw /*= false */, timer_source_div_t sd /*= TIMER_SOURCE_DIV_1*/) {
 /* -------------------------------------------------------------------------- */
   _enabled = true;
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
   _enabled &= cfg_pin(max_index);
   
   if(_enabled) {

--- a/cores/arduino/variant_helper.cpp
+++ b/cores/arduino/variant_helper.cpp
@@ -1,13 +1,10 @@
 #include "Arduino.h"
 #include "variant.h"
 
-extern const PinMuxCfg_t g_pin_cfg[];
-extern const size_t g_pin_cfg_size;
-
 std::array<uint16_t, 3> getPinCfgs(const pin_size_t pin, PinCfgReq_t req) {
 
   std::array<uint16_t, 3> ret = {0 , 0, 0};
-  if (pin > g_pin_cfg_size) {
+  if (pin > PINS_COUNT) {
     return ret;
   }
 

--- a/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
@@ -142,7 +142,7 @@ bool R7FA4M1_CAN::begin(CanBitRate const can_bitrate)
 
   /* Configure the pins for CAN.
    */
-  int const max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int const max_index = PINS_COUNT;
   init_ok &= cfg_pins(max_index, _can_tx_pin, _can_rx_pin);
 
   /* Configure the interrupts.

--- a/libraries/Arduino_CAN/src/R7FA6M5_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA6M5_CAN.cpp
@@ -105,7 +105,7 @@ bool R7FA6M5_CAN::begin(CanBitRate const can_bitrate)
 
   /* Configure the pins for CAN.
    */
-  int const max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int const max_index = PINS_COUNT;
   auto [cfg_init_ok, cfg_channel] = cfg_pins(max_index, _can_tx_pin, _can_rx_pin);
   init_ok &= cfg_init_ok;
   _canfd_cfg.channel = cfg_channel;

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -26,13 +26,6 @@
 using namespace arduino;
 
 /**************************************************************************************
- * EXTERN GLOBAL CONSTANTS
- **************************************************************************************/
-
-extern const PinMuxCfg_t g_pin_cfg[];
-extern const size_t g_pin_cfg_size;
-
-/**************************************************************************************
  * GLOBAL MEMBER VARIABLES
  **************************************************************************************/
 
@@ -73,7 +66,7 @@ void ArduinoSPI::begin()
   /* Configure the pins and auto-determine channel and
    * whether or not we are using a SCI.
    */
-  int const max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int const max_index = PINS_COUNT;
   auto [cfg_pins_ok, cfg_channel, cfg_is_sci] = cfg_pins(max_index, _miso_pin, _mosi_pin, _sck_pin, _periph_mode);
   init_ok &= cfg_pins_ok;
   _channel = cfg_channel;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -275,7 +275,7 @@ done:
 void TwoWire::begin(void) {
 /* -------------------------------------------------------------------------- */  
   init_ok = true;
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
 
   init_ok &= cfg_pins(max_index);
 

--- a/variants/MINIMA/pins_arduino.h
+++ b/variants/MINIMA/pins_arduino.h
@@ -4,6 +4,9 @@
 
 // Pin count
 // ----
+#ifdef __cplusplus
+extern "C" unsigned int PINCOUNT_fn();
+#endif
 #define PINS_COUNT           (PINCOUNT_fn())
 #define NUM_DIGITAL_PINS     (22u)
 #define NUM_ANALOG_INPUTS    (6u)

--- a/variants/MINIMA/variant.cpp
+++ b/variants/MINIMA/variant.cpp
@@ -50,10 +50,14 @@ extern "C" const PinMuxCfg_t g_pin_cfg[] = {
   { BSP_IO_PORT_00_PIN_13,    P013   }, /* (22) RX LED  */
 };
 
-extern "C" const size_t g_pin_cfg_size = sizeof(g_pin_cfg);
+extern "C" {
+    unsigned int PINCOUNT_fn() {
+        return (sizeof(g_pin_cfg) / sizeof(g_pin_cfg[0]));
+    }
+}
 
 int32_t getPinIndex(bsp_io_port_pin_t p) {
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
   int rv = -1;
   for(int i = 0; i < max_index; i++) {
     if(g_pin_cfg[i].pin == p) {

--- a/variants/MUXTO/pins_arduino.h
+++ b/variants/MUXTO/pins_arduino.h
@@ -1,17 +1,12 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C" unsigned int PINCOUNT_fn();
-extern "C" unsigned int I2C_COUNT_fn();
-extern "C" unsigned int SPI_COUNT_fn();
-extern "C" unsigned int UART_COUNT_fn();
-extern "C" unsigned int SCI_COUNT_fn();
-#endif
-
 #define PIN(X,Y) (X * 16 + Y)
 
 // Pin count
 // ----
+#ifdef __cplusplus
+extern "C" unsigned int PINCOUNT_fn();
+#endif
 #define PINS_COUNT           (PINCOUNT_fn())
 #define NUM_DIGITAL_PINS     (22u)
 #define NUM_ANALOG_INPUTS    (6u)

--- a/variants/MUXTO/variant.cpp
+++ b/variants/MUXTO/variant.cpp
@@ -62,7 +62,11 @@ extern "C" const PinMuxCfg_t g_pin_cfg[] = {
   { BSP_IO_PORT_02_PIN_06,    P206   }, /* (27) D27  */
 };
 
-extern "C" const size_t g_pin_cfg_size = sizeof(g_pin_cfg);
+extern "C" {
+    unsigned int PINCOUNT_fn() {
+        return (sizeof(g_pin_cfg) / sizeof(g_pin_cfg[0]));
+    }
+}
 
 const ioport_pin_cfg_t bsp_pin_cfg_data[] = {
   { ((uint32_t) IOPORT_CFG_PERIPHERAL_PIN | (uint32_t) IOPORT_PERIPHERAL_USB_FS), BSP_IO_PORT_09_PIN_15 },

--- a/variants/PORTENTA_C33/pins_arduino.h
+++ b/variants/PORTENTA_C33/pins_arduino.h
@@ -1,17 +1,12 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C" unsigned int PINCOUNT_fn();
-extern "C" unsigned int I2C_COUNT_fn();
-extern "C" unsigned int SPI_COUNT_fn();
-extern "C" unsigned int UART_COUNT_fn();
-extern "C" unsigned int SCI_COUNT_fn();
-#endif
-
 #define PIN(X,Y) (X * 16 + Y)
 
 // Pin count
 // ----
+#ifdef __cplusplus
+extern "C" unsigned int PINCOUNT_fn();
+#endif
 #define PINS_COUNT           (PINCOUNT_fn())
 #define NUM_DIGITAL_PINS     (121u)
 #define NUM_ANALOG_INPUTS    (8u)

--- a/variants/PORTENTA_C33/variant.cpp
+++ b/variants/PORTENTA_C33/variant.cpp
@@ -198,10 +198,14 @@ extern "C" const PinMuxCfg_t g_pin_cfg[] = {
   { BSP_IO_PORT_02_PIN_08,  P208 }, /*   D121   |   QSPI IO3    */
 };
 
-extern "C" const size_t g_pin_cfg_size = sizeof(g_pin_cfg);
+extern "C" {
+    unsigned int PINCOUNT_fn() {
+        return (sizeof(g_pin_cfg) / sizeof(g_pin_cfg[0]));
+    }
+}
 
 int32_t getPinIndex(bsp_io_port_pin_t p) {
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
   int rv = -1;
   for(int i = 0; i < max_index; i++) {
     if(g_pin_cfg[i].pin == p) {

--- a/variants/UNOWIFIR4/pins_arduino.h
+++ b/variants/UNOWIFIR4/pins_arduino.h
@@ -4,6 +4,9 @@
 
 // Pin count
 // ----
+#ifdef __cplusplus
+extern "C" unsigned int PINCOUNT_fn();
+#endif
 #define PINS_COUNT           (PINCOUNT_fn())
 #define NUM_DIGITAL_PINS     (22u)
 #define NUM_ANALOG_INPUTS    (6u)

--- a/variants/UNOWIFIR4/variant.cpp
+++ b/variants/UNOWIFIR4/variant.cpp
@@ -69,10 +69,14 @@ extern "C" const PinMuxCfg_t g_pin_cfg[] = {
   { BSP_IO_PORT_02_PIN_13,    P213   }, /* (38) D38  */
 };
 
-extern "C" const size_t g_pin_cfg_size = sizeof(g_pin_cfg);
+extern "C" {
+    unsigned int PINCOUNT_fn() {
+        return (sizeof(g_pin_cfg) / sizeof(g_pin_cfg[0]));
+    }
+}
 
 int32_t getPinIndex(bsp_io_port_pin_t p) {
-  int max_index = g_pin_cfg_size / sizeof(g_pin_cfg[0]);
+  int max_index = PINS_COUNT;
   int rv = -1;
   for(int i = 0; i < max_index; i++) {
     if(g_pin_cfg[i].pin == p) {


### PR DESCRIPTION
Fixes https://github.com/arduino/ArduinoCore-renesas/issues/102

@WestfW this should fix the PINCOUNT macro being partially missing, while refactoring the code to use it.