### PR TITLE
platform.txt - core platform path for tinyusb

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -49,7 +49,7 @@ compiler.ar.extra_flags=
 compiler.objcopy.eep.extra_flags=
 compiler.elf2hex.extra_flags=
 
-tinyusb.includes="-I{runtime.platform.path}/cores/arduino/tinyusb"
+tinyusb.includes="-I{build.core.path}/tinyusb"
 
 # USB Flags
 # ---------


### PR DESCRIPTION
I think the `tinyusb path` should use core platform path `{build.core.path}`, not board platform path `{runtime.platform.path}`.
the board platform can still override it in its platform.txt