### PR TITLE
Add method to allow the GPT Timer period not to be buffered.

### DIFF
--- a/cores/arduino/FspTimer.cpp
+++ b/cores/arduino/FspTimer.cpp
@@ -459,7 +459,7 @@ bool FspTimer::set_period(uint32_t p) {
         }
     }
         else {
-            // Not buffered set it directl
+            // Not buffered set it directly
             gpt_timer->ctrl.p_reg->GTPR = p;
         }
     }

--- a/cores/arduino/FspTimer.cpp
+++ b/cores/arduino/FspTimer.cpp
@@ -11,7 +11,7 @@ bool FspTimer::force_pwm_reserved = false;
 TimerAvail_t FspTimer::gpt_used_channel[GPT_HOWMANY] = { TIMER_FREE };
 TimerAvail_t FspTimer::agt_used_channel[AGT_HOWMANY] = { TIMER_FREE };
 
-FspTimer::FspTimer(): init_ok(false), agt_timer(nullptr), gpt_timer(nullptr), type(GPT_TIMER), _buffer_period(true) {
+FspTimer::FspTimer(): init_ok(false), agt_timer(nullptr), gpt_timer(nullptr), type(GPT_TIMER), _period_buffer(true) {
     // AGT0 is always used for timekeeping (millis() and micros())
     // agt_used_channel[0] = TIMER_USED;
     timer_cfg.cycle_end_irq = FSP_INVALID_VECTOR;
@@ -453,7 +453,7 @@ bool FspTimer::set_period(uint32_t p) {
 /* -------------------------------------------------------------------------- */    
 
     if(type == GPT_TIMER && gpt_timer != nullptr) {
-        if (_buffer_period) {
+        if (_period_buffer) {
         if (R_GPT_PeriodSet(&(gpt_timer->ctrl), p) != FSP_SUCCESS) {
             return false;
         }
@@ -477,17 +477,17 @@ bool FspTimer::set_period(uint32_t p) {
 
 
 /* -------------------------------------------------------------------------- */
-bool FspTimer::use_period_buffer(bool buffer_period) {
+bool FspTimer::set_period_buffer(bool period_buffer) {
 /* -------------------------------------------------------------------------- */    
 
-    if (_buffer_period == (uint8_t)buffer_period) {
+    if (_period_buffer == (uint8_t)period_buffer) {
         return true;
     }
 
-    _buffer_period = (uint8_t)buffer_period;
+    _period_buffer = (uint8_t)period_buffer;
     if(type == GPT_TIMER && gpt_timer != nullptr) {
 
-        if (buffer_period) {
+        if (period_buffer) {
             gpt_timer->ctrl.p_reg->GTBER_b.PR = 1;
             gpt_timer->ctrl.p_reg->GTBER_b.BD1 = 0;
         }

--- a/cores/arduino/FspTimer.h
+++ b/cores/arduino/FspTimer.h
@@ -95,7 +95,7 @@ class FspTimer {
     uint32_t _duty_cycle_counts;
     timer_source_div_t _sd;
     uint8_t type;
-    uint8_t _buffer_period;
+    uint8_t _period_buffer;
     void set_period_counts(uint8_t tp, float period, uint32_t max);
     TimerIrqCfg_t get_cfg_for_irq();
     static bool force_pwm_reserved;
@@ -112,8 +112,7 @@ class FspTimer {
     bool reset();
     bool set_duty_cycle(uint32_t const duty_cycle_counts, TimerPWMChannel_t pwm_ch);
     bool set_period(uint32_t p);
-    bool use_period_buffer(bool buffer_period);
-
+    bool set_period_buffer(bool period_buffer);
     bool close();
     void enable_pwm_channel(TimerPWMChannel_t pwm_channel);
     uint32_t get_counter();

--- a/cores/arduino/FspTimer.h
+++ b/cores/arduino/FspTimer.h
@@ -95,6 +95,7 @@ class FspTimer {
     uint32_t _duty_cycle_counts;
     timer_source_div_t _sd;
     uint8_t type;
+    uint8_t _buffer_period;
     void set_period_counts(uint8_t tp, float period, uint32_t max);
     TimerIrqCfg_t get_cfg_for_irq();
     static bool force_pwm_reserved;
@@ -111,6 +112,8 @@ class FspTimer {
     bool reset();
     bool set_duty_cycle(uint32_t const duty_cycle_counts, TimerPWMChannel_t pwm_ch);
     bool set_period(uint32_t p);
+    bool use_period_buffer(bool buffer_period);
+
     bool close();
     void enable_pwm_channel(TimerPWMChannel_t pwm_channel);
     uint32_t get_counter();


### PR DESCRIPTION
During code review of changes I made to the Servo library: https://github.com/arduino-libraries/Servo/pull/116

@iabdalkader requested that I move all of the platform specific timer changes into the core instead of being in the hardware specific sub-directory of the Servo library.

This change adds a method to tell the GPT timer, that when I make a change to the pseriod (set_period(p) ) that I want the change to happen now and not be buffered.

And updated the set_period method to check for this and directly set the not buffered register with the new period.