### PR TITLE
WiFiS3 example WiFiPagerServer

### DIFF
--- a/libraries/WiFiS3/examples/WiFiPagerServer/WiFiPagerServer.ino
+++ b/libraries/WiFiS3/examples/WiFiPagerServer/WiFiPagerServer.ino
@@ -5,6 +5,22 @@
   messages to all connected clients. Connect two or more
   telnet sessions to see how server.available() and
   server.print() work.
+
+  You may need to update the firwmare on your WiFi module.
+  Download the files and follow the instructions from
+  https://github.com/arduino/uno-r4-wifi-usb-bridge/releases/tag/0.3.0 .
+
+  Run a nmap scan or check the output of this sketch to obtain
+  the IP given to your DHCP server to this sketch, i.e.
+
+  Nmap scan report for esp32s3-C4E524 (192.168.8.161)
+    Host is up (0.012s latency).
+    Not shown: 999 closed ports
+    PORT   STATE SERVICE
+    23/tcp open  telnet
+
+  Connect via telnet (at least twice):
+    telnet 192.168.8.161
 */
 
 #include <WiFiS3.h>

--- a/libraries/WiFiS3/examples/WiFiPagerServer/WiFiPagerServer.ino
+++ b/libraries/WiFiS3/examples/WiFiPagerServer/WiFiPagerServer.ino
@@ -1,0 +1,73 @@
+/*
+  WiFi Pager Server
+
+  The example is a simple server that echoes any incoming
+  messages to all connected clients. Connect two or more
+  telnet sessions to see how server.available() and
+  server.print() work.
+*/
+
+#include <WiFiS3.h>
+
+#include "arduino_secrets.h"
+///////please enter your sensitive data in the Secret tab/arduino_secrets.h
+char ssid[] = SECRET_SSID;        // your network SSID (name)
+char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
+
+int status = WL_IDLE_STATUS;
+
+WiFiServer server(23);
+
+void setup() {
+
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the WiFi module:
+  if (WiFi.status() == WL_NO_MODULE) {
+    Serial.println("Communication with WiFi module failed!");
+    // don't continue
+    while (true);
+  }
+
+  String fv = WiFi.firmwareVersion();
+  if (fv < WIFI_FIRMWARE_LATEST_VERSION) {
+    Serial.println("Please upgrade the firmware");
+  }
+
+  // attempt to connect to WiFi network:
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(ssid);
+    // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
+    status = WiFi.begin(ssid, pass);
+
+    // wait 10 seconds for connection:
+    delay(10000);
+  }
+
+  server.begin();
+
+  IPAddress ip = WiFi.localIP();
+  Serial.println();
+  Serial.println("Connected to WiFi network.");
+  Serial.print("To access the server, connect with Telnet client to ");
+  Serial.print(ip);
+  Serial.println(" 23");
+}
+
+void loop() {
+
+  WiFiClient client = server.available(); // returns first client which has data to read or a 'false' client
+  if (client) { // client is true only if it is connected and has data to read
+    String s = client.readStringUntil('\n'); // read the message incoming from one of the clients
+    s.trim(); // trim eventual \r
+    Serial.println(s); // print the message to Serial Monitor
+    client.print("echo: "); // this is only for the sending client
+    server.println(s); // send the message to all connected clients
+    server.flush(); // flush the buffers
+  }
+}

--- a/libraries/WiFiS3/examples/WiFiPagerServer/arduino_secrets.h
+++ b/libraries/WiFiS3/examples/WiFiPagerServer/arduino_secrets.h
@@ -1,0 +1,2 @@
+#define SECRET_SSID ""
+#define SECRET_PASS ""


### PR DESCRIPTION
to demonstrate how server.available and print-to-all-clients work

other libraries including the Ethernet library have this example I created because in other examples this is not so clear.

the example doesn't work right without the server.available fix in the S3 firmware https://github.com/arduino/uno-r4-wifi-usb-bridge/pull/20