### PR TITLE
Fix the incorrect comments in the examples of the WIFI S3 library.

### DIFF
--- a/libraries/WiFiS3/examples/AP_SimpleWebServer/AP_SimpleWebServer.ino
+++ b/libraries/WiFiS3/examples/AP_SimpleWebServer/AP_SimpleWebServer.ino
@@ -15,7 +15,7 @@
   by Tom Igoe
   adapted to WiFi AP by Adafruit
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#access-point
  */
 

--- a/libraries/WiFiS3/examples/ConnectWithWPA/ConnectWithWPA.ino
+++ b/libraries/WiFiS3/examples/ConnectWithWPA/ConnectWithWPA.ino
@@ -8,7 +8,7 @@
   modified 31 May 2012
   by Tom Igoe
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#connect-with-wpa
  */
 #include <WiFiS3.h>

--- a/libraries/WiFiS3/examples/ScanNetworks/ScanNetworks.ino
+++ b/libraries/WiFiS3/examples/ScanNetworks/ScanNetworks.ino
@@ -12,7 +12,7 @@
   modified 21 Junn 2012
   by Tom Igoe and Jaymes Dec
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#scan-networks
  */
 

--- a/libraries/WiFiS3/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/libraries/WiFiS3/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -13,7 +13,7 @@
   created 1 Mar 2017
   by Arturo Guadalupi
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#scan-networks-advanced
 */
 

--- a/libraries/WiFiS3/examples/SimpleWebServerWiFi/SimpleWebServerWiFi.ino
+++ b/libraries/WiFiS3/examples/SimpleWebServerWiFi/SimpleWebServerWiFi.ino
@@ -20,7 +20,7 @@
   created 25 Nov 2012
   by Tom Igoe
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#simple-webserver
  */
 

--- a/libraries/WiFiS3/examples/WiFiChatServer/WiFiChatServer.ino
+++ b/libraries/WiFiS3/examples/WiFiChatServer/WiFiChatServer.ino
@@ -17,7 +17,7 @@
   modified 31 May 2012
   by Tom Igoe
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-chat-server
  */
 

--- a/libraries/WiFiS3/examples/WiFiUdpNtpClient/WiFiUdpNtpClient.ino
+++ b/libraries/WiFiS3/examples/WiFiUdpNtpClient/WiFiUdpNtpClient.ino
@@ -15,7 +15,7 @@
 
   This code is in the public domain.
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-udp-ntp-client
  */
 

--- a/libraries/WiFiS3/examples/WiFiUdpSendReceiveString/WiFiUdpSendReceiveString.ino
+++ b/libraries/WiFiS3/examples/WiFiUdpSendReceiveString/WiFiUdpSendReceiveString.ino
@@ -7,7 +7,7 @@
   created 30 December 2012
   by dlf (Metodo2 srl)
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-udp-send-receive-string
  */
 

--- a/libraries/WiFiS3/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/libraries/WiFiS3/examples/WiFiWebClient/WiFiWebClient.ino
@@ -16,7 +16,7 @@
   modified 31 May 2012
   by Tom Igoe
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-web-client
  */
 

--- a/libraries/WiFiS3/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
+++ b/libraries/WiFiS3/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
@@ -12,7 +12,7 @@
 
  This code is in the public domain.
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-web-client-repeating
  */
 

--- a/libraries/WiFiS3/examples/WiFiWebClientSSL/WiFiWebClientSSL.ino
+++ b/libraries/WiFiS3/examples/WiFiWebClientSSL/WiFiWebClientSSL.ino
@@ -4,7 +4,7 @@
   Remeber to update the CA certificates using CertificateUploader sketch
   before using this sketch.
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-web-client-ssl
 */
 

--- a/libraries/WiFiS3/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/libraries/WiFiS3/examples/WiFiWebServer/WiFiWebServer.ino
@@ -15,7 +15,7 @@
  by Tom Igoe
 
 
-  Find the full UNO R4 WiFi RTC documentation here:
+  Find the full UNO R4 WiFi Network documentation here:
   https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples#wi-fi-web-server
  */
 


### PR DESCRIPTION
Hi, when I was browsing https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples, I noticed that the descriptions in the comments of the code were incorrect. All examples related to networking were written as RTC. So, I tried to [edit the document](https://github.com/arduino/docs-content/blob/main/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/wifi-examples/wifi-examples.md?plain=1). Later on, I found that the code in the document is based on the corresponding example code from this repository, so I made this modification here. Hope these modifications can be helpful.