### PR TITLE
WiFiS3 WiFiServer operator bool

### DIFF
--- a/libraries/WiFiS3/src/WiFiServer.cpp
+++ b/libraries/WiFiS3/src/WiFiServer.cpp
@@ -84,6 +84,11 @@ void WiFiServer::end() {
    }
 }
 
+WiFiServer::operator bool()
+{
+   return (_sock != -1);
+}
+
 bool WiFiServer::operator==(const WiFiServer& whs)
 {
        return _sock == whs._sock;

--- a/libraries/WiFiS3/src/WiFiServer.h
+++ b/libraries/WiFiS3/src/WiFiServer.h
@@ -42,6 +42,7 @@ public:
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   void end();
+  explicit operator bool();
   virtual bool operator==(const WiFiServer&);
   virtual bool operator!=(const WiFiServer& whs)
   {


### PR DESCRIPTION
Server implementation in the Ethernet library for W5x00 has operator bool.

WiFiServer in esp8266 and esp32 Arduino WiFi library has bool operator.
