### PR TITLE
Add a USB mass storage disconnected callback

### DIFF
--- a/libraries/UsbHostMsd/UsbHostMsd.cpp
+++ b/libraries/UsbHostMsd/UsbHostMsd.cpp
@@ -26,7 +26,7 @@ extern "C" uint8_t usb_host_msd_get_lun_num();
 extern "C" uint32_t usb_host_msd_get_num_of_blocks(uint8_t lun);
 extern "C" uint32_t usb_host_msd_get_block_size(uint8_t lun);
 extern "C" void usb_host_msd_attach_mnt_cbk(void (*fnc)(void));
-
+extern "C" void usb_host_msd_attach_umnt_cbk(void (*fnc)(void));
 
 /* -------------------------------------------------------------------------- */
 /*                               CONSTRUCTOR                                  */
@@ -224,4 +224,11 @@ const char *USBHostMSD::get_type() const {
 
 bool USBHostMSD::attach_detected_callback(void (*cbk)()) {
     usb_host_msd_attach_mnt_cbk(cbk);
+    return true;
 }
+
+bool USBHostMSD::attach_removed_callback(void (*cbk)()) {
+    usb_host_msd_attach_umnt_cbk(cbk);
+    return true;
+}
+

--- a/libraries/UsbHostMsd/UsbHostMsd.h
+++ b/libraries/UsbHostMsd/UsbHostMsd.h
@@ -47,6 +47,7 @@ public:
     virtual bool select_lun(uint8_t lun);
     virtual uint8_t get_lun_num();
     bool attach_detected_callback(void (*cbk)());
+    bool attach_removed_callback(void (*cbk)());
     
 private:
     uint8_t get_lun();

--- a/libraries/UsbHostMsd/tu_msc.c
+++ b/libraries/UsbHostMsd/tu_msc.c
@@ -68,9 +68,14 @@ uint32_t usb_host_msd_get_block_size(uint8_t lun) {
 }
 
 static void (*mount_fnc)(void) = NULL;
+static void (*unmount_fnc)(void) = NULL;
 
 void usb_host_msd_attach_mnt_cbk(void (*fnc)(void)) {
   mount_fnc = fnc;
+}
+
+void usb_host_msd_attach_umnt_cbk(void (*fnc)(void)) {
+  unmount_fnc = fnc;
 }
 
 //--------------------------------------------------------------------+
@@ -166,6 +171,10 @@ void tuh_msc_umount_cb(uint8_t dev_addr) {
   }
 
   device_address = -1;
+
+  if (unmount_fnc != NULL) {
+    unmount_fnc();
+  }
 
 //  uint8_t phy_disk = dev_addr-1;
 //


### PR DESCRIPTION
Adds a USB mass storage disconnected callback in a similar style as the connected callback.