### PR TITLE
WiFiS3 client connect timeout

### DIFF
--- a/libraries/WiFiS3/src/WiFiClient.cpp
+++ b/libraries/WiFiS3/src/WiFiClient.cpp
@@ -39,16 +39,8 @@ void WiFiClient::getSocket() {
 
 /* -------------------------------------------------------------------------- */
 int WiFiClient::connect(IPAddress ip, uint16_t port){
-/* -------------------------------------------------------------------------- */   
-   getSocket();
-   if(_sock >= 0) {
-      string res = "";
-      modem.begin();
-      if(modem.write(string(PROMPT(_CLIENTCONNECTIP)),res, "%s%d,%s,%d\r\n" , CMD_WRITE(_CLIENTCONNECTIP), _sock, ip.toString().c_str(), port)) {
-         return 1;
-      }  
-   }
-   return 0;
+/* -------------------------------------------------------------------------- */
+   return connect(ip.toString().c_str(), port);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -58,9 +50,15 @@ int WiFiClient::connect(const char *host, uint16_t port){
    if(_sock >= 0) {
       string res = "";
       modem.begin();
+      if (_connectionTimeout) {
+         if(modem.write(string(PROMPT(_CLIENTCONNECT)),res, "%s%d,%s,%d,%d\r\n" , CMD_WRITE(_CLIENTCONNECT), _sock, host,port, _connectionTimeout)) {
+            return 1;
+         }
+      } else {
       if(modem.write(string(PROMPT(_CLIENTCONNECTNAME)),res, "%s%d,%s,%d\r\n" , CMD_WRITE(_CLIENTCONNECTNAME), _sock, host,port)) {
          return 1;
       }  
+      }
    }
    return 0;
 }

--- a/libraries/WiFiS3/src/WiFiClient.h
+++ b/libraries/WiFiS3/src/WiFiClient.h
@@ -62,12 +62,17 @@ public:
   virtual IPAddress remoteIP();
   virtual uint16_t remotePort();
 
+  void setConnectionTimeout(int timeout) {
+    _connectionTimeout = timeout;
+  }
+
   friend class WiFiServer;
   
   using Print::write;
 
 protected:
   int _sock;
+  int _connectionTimeout = 0;
   void getSocket();
   std::shared_ptr<FifoBuffer<uint8_t,RX_BUFFER_DIM>> rx_buffer;
   int _read();

--- a/libraries/WiFiS3/src/WiFiSSLClient.cpp
+++ b/libraries/WiFiS3/src/WiFiSSLClient.cpp
@@ -29,13 +29,7 @@ void WiFiSSLClient::getSocket() {
 /* -------------------------------------------------------------------------- */
 int WiFiSSLClient::connect(IPAddress ip, uint16_t port) {
 /* -------------------------------------------------------------------------- */
-   getSocket();
-
-   string res = "";
-   if(modem.write(string(PROMPT(_SSLCLIENTCONNECTIP)),res, "%s%d,%s,%d\r\n" , CMD_WRITE(_SSLCLIENTCONNECTIP), _sock, ip.toString(), port)) {
-      return 1;
-   }
-   return 0;
+   return connect(ip.toString().c_str(), port);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -46,8 +40,14 @@ int WiFiSSLClient::connect(const char* host, uint16_t port) {
       setCACert();
    }
    string res = "";
+   if (_connectionTimeout) {
+      if(modem.write(string(PROMPT(_SSLCLIENTCONNECT)),res, "%s%d,%s,%d,%d\r\n" , CMD_WRITE(_SSLCLIENTCONNECT), _sock, host,port, _connectionTimeout)) {
+         return 1;
+      }
+   } else {
    if(modem.write(string(PROMPT(_SSLCLIENTCONNECTNAME)),res, "%s%d,%s,%d\r\n" , CMD_WRITE(_SSLCLIENTCONNECTNAME), _sock, host, port)) {
       return 1;
+   }
    }
    return 0;
 }


### PR DESCRIPTION
The corresponding PR in firmware is https://github.com/arduino/uno-r4-wifi-usb-bridge/pull/23

If connect timeout is not set on client, the library will use CONNECT commands which exist in older versions of the firmware. 

There is no need to use extra command to connect with IP address. The connect with hostname uses hostByName which first attempts to convert the string to IP address. So to avoid duplicate code, this PR redirects connect with IP to connect with hostname.

The Modem bug fix PR  https://github.com/arduino/ArduinoCore-renesas/pull/147 is need to see the effect of the timeout.

the checks will fail while the PR in firmware is not merged

overview of Client API in Arduino networking libraries:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#client-getters-and-setters