### PR TITLE
Fix and improvements on Ethernet driver and lwip wrapper

### DIFF
--- a/libraries/Ethernet/src/EthernetDriver.cpp
+++ b/libraries/Ethernet/src/EthernetDriver.cpp
@@ -64,7 +64,7 @@ private:
 #define ETHER_FRAME_TRANSFER_COMPLETED          (1UL << 21)
 #define ETHER_MAGIC_PACKET_DETECTED_MASK        (1UL << 1)
 
-static volatile bool frame_transmitted_flag = false;
+static volatile bool frame_being_transmitted = false;
 static EthernetDriver eth_driver;
 
 static uint8_t eth_tx_buffer[ETH_BUFF_DIM];
@@ -230,7 +230,7 @@ void EthernetDriver::irq_callback(ether_callback_args_t * p_args) {
             if (ETHER_FRAME_TRANSFER_COMPLETED == (reg_eesr & ETHER_FRAME_TRANSFER_COMPLETED)) {
                 
                 
-                frame_transmitted_flag = true;
+                frame_being_transmitted = false;
                 /* FRAME TRANSMISSION COMPLETED */
                 if(frame_transmitted != nullptr) {
                     frame_transmitted();
@@ -341,18 +341,27 @@ void eth_release_rx_buffer() {
 
 
 bool eth_output(uint8_t *buf, uint16_t dim) {
-    frame_transmitted_flag = false;
-    fsp_err_t err = R_ETHER_Write ( eth_driver.get_ctrl(), buf, dim);
-    if(err == FSP_SUCCESS) {
-        
-        while(!frame_transmitted_flag) {
+    bool retval = true;
 
-        }
-        return true;
+    // if(frame_being_transmitted) {
+    //     retval = false;
+    // } else {
+    fsp_err_t err = R_ETHER_Write(eth_driver.get_ctrl(), buf, dim);
+    if(err == FSP_SUCCESS) {
+        frame_being_transmitted = true;
+        retval = true;
     }
     else {
-        return false;
+        retval = false;
     }
+    // }
+
+    return retval;
+}
+
+// this function return true if the tx buffer is not being used for the transmission of another frame
+bool eth_output_can_transimit() {
+    return !frame_being_transmitted;
 }
 
 uint8_t *eth_input(volatile uint32_t *dim) {

--- a/libraries/Ethernet/src/EthernetDriver.h
+++ b/libraries/Ethernet/src/EthernetDriver.h
@@ -5,8 +5,9 @@
 #include "r_ether_phy.h"
 #include "r_ether_api.h"
 #include "r_ether.h"
+#include <functional>
 
-using EtherCallback_f        = void (*)(void);
+using EtherCallback_f        = std::function<void(void)>;
 
 #define ETHERNET_IRQ_PRIORITY   10
 
@@ -23,6 +24,7 @@ bool eth_init();
 void eth_execute_link_process();
 uint8_t *eth_input(volatile uint32_t *dim);
 bool eth_output(uint8_t *buf, uint16_t dim);
+bool eth_output_can_transimit();
 void eth_release_rx_buffer();
 uint8_t *eth_get_tx_buffer(uint16_t *size);
 void eth_set_rx_frame_cbk(EtherCallback_f fn);
@@ -31,7 +33,6 @@ void eth_set_link_on_cbk(EtherCallback_f fn);
 void eth_set_link_off_cbk(EtherCallback_f fn);
 void eth_set_lan_wake_up_cbk(EtherCallback_f fn);
 void eth_set_magic_packet_cbk(EtherCallback_f fn);
-
 
 
 #endif

--- a/libraries/lwIpWrapper/src/CNetIf.cpp
+++ b/libraries/lwIpWrapper/src/CNetIf.cpp
@@ -1,4 +1,5 @@
 #include "CNetIf.h"
+#include <functional>
 
 IPAddress CNetIf::default_ip("192.168.0.10");
 IPAddress CNetIf::default_nm("255.255.255.0");
@@ -9,7 +10,6 @@ CNetIf* CLwipIf::net_ifs[] = { nullptr };
 bool CLwipIf::wifi_hw_initialized = false;
 bool CLwipIf::connected_to_access_point = false;
 WifiStatus_t CLwipIf::wifi_status = WL_IDLE_STATUS;
-std::queue<struct pbuf*> CLwipIf::eth_queue;
 bool CLwipIf::pending_eth_rx = false;
 
 FspTimer CLwipIf::timer;
@@ -69,7 +69,22 @@ CLwipIf::CLwipIf()
         ch = FspTimer::get_available_timer(type, true);
     }
 
-    timer.begin(TIMER_MODE_PERIODIC, type, ch, 10.0, 50.0, timer_cb);
+    /*
+     * NOTE Timer and buffer size
+     * The frequency for the timer highly influences the memory requirements for the desired transfer speed
+     * You can calculate the buffer size required to achieve that performance from the following formula:
+     * buffer_size[byte] = Speed[bit/s] * timer_frequency[Hz]^-1 / 8
+     *
+     * In the case of portenta C33, the maximum speed achievable was measured with 
+     * iperf2 tool (provided by lwip) and can reach up to 12Mbit/s.
+     * Further improvements can be made, but if we desire to reach that speed the buffer size
+     * and the timer frequency should be designed accordingly.
+     * buffer = 12 * 10^6 bit/s * (100Hz)^-1 / 8 = 15000 Byte = 15KB
+     *
+     * Since this is a constrained environment we could accept performance loss and 
+     * delegate lwip to handle lost packets.
+     */
+    timer.begin(TIMER_MODE_PERIODIC, type, ch, 100.0, 50.0, timer_cb);
     timer.setup_overflow_irq();
     timer.open();
     timer.start();
@@ -129,22 +144,22 @@ CLwipIf::~CLwipIf()
 
 /* -------------------------------------------------------------------------- */
 int CLwipIf::disconnectEventcb(CCtrlMsgWrapper *resp) {
-   (void)resp;
-   if(CLwipIf::connected_to_access_point) {
-      wifi_status = WL_DISCONNECTED;
-      if(net_ifs[NI_WIFI_STATION] != nullptr) {
-         net_ifs[NI_WIFI_STATION]->setLinkDown();
-      }
-   }
-   return ESP_CONTROL_OK;
+    (void)resp;
+    if(CLwipIf::connected_to_access_point) {
+        wifi_status = WL_DISCONNECTED;
+        if(net_ifs[NI_WIFI_STATION] != nullptr) {
+            net_ifs[NI_WIFI_STATION]->setLinkDown();
+        }
+    }
+    return ESP_CONTROL_OK;
 }
 
 
 /* -------------------------------------------------------------------------- */
 int CLwipIf::initEventCb(CCtrlMsgWrapper *resp) {
-   (void)resp;
-   CLwipIf::wifi_hw_initialized = true;
-   return ESP_CONTROL_OK;
+    (void)resp;
+    CLwipIf::wifi_hw_initialized = true;
+    return ESP_CONTROL_OK;
 }
 
 
@@ -252,56 +267,48 @@ CNetIf* CLwipIf::get(NetIfType_t type,
 }
 
 /* -------------------------------------------------------------------------- */
-void CLwipIf::ethLinkUp()
+void CEth::handleEthRx()
 {
-    /* -------------------------------------------------------------------------- */
-    if (net_ifs[NI_ETHERNET] != nullptr) {
-        net_ifs[NI_ETHERNET]->setLinkUp();
-    }
-}
+    /*
+     * This function is called by the ethernet driver, when a frame is receiverd,
+     * as a callback inside an interrupt context.
+     * It is required to be as fast as possible and not perform busy waits.
+     *
+     * The idea is the following:
+     * - take the rx buffer pointer
+     * - try to allocate a pbuf of the desired size
+     *   - if it is possible copy the the buffer inside the pbuf and give it to lwip netif
+     * - release the buffer
+     *
+     * If the packet is discarded the upper TCP/IP layers should handle the retransmission of the lost packets.
+     * This should not happen really often if the buffers and timers are designed taking into account the
+     * desired performance
+     */
+    __disable_irq();
 
-/* -------------------------------------------------------------------------- */
-void CLwipIf::ethLinkDown()
-{
-    /* -------------------------------------------------------------------------- */
-    if (net_ifs[NI_ETHERNET] != nullptr) {
-        net_ifs[NI_ETHERNET]->setLinkDown();
-    }
-}
+    volatile uint32_t rx_frame_dim = 0;
+    volatile uint8_t* rx_frame_buf = eth_input(&rx_frame_dim);
+    if (rx_frame_dim > 0 && rx_frame_buf != nullptr) {
+        struct pbuf* p=nullptr;
 
-/* -------------------------------------------------------------------------- */
-void CLwipIf::ethFrameRx()
-{
-    /* -------------------------------------------------------------------------- */
+        p = pbuf_alloc(PBUF_RAW, rx_frame_dim, PBUF_RAM);
 
-    if (pending_eth_rx) {
-        pending_eth_rx = false;
-        volatile uint32_t rx_frame_dim = 0;
-        volatile uint8_t* rx_frame_buf = eth_input(&rx_frame_dim);
-        if (rx_frame_dim > 0 && rx_frame_buf != nullptr) {
-            while (rx_frame_dim % 4 != 0) {
-                rx_frame_dim++;
-            }
-            struct pbuf* p = pbuf_alloc(PBUF_RAW, rx_frame_dim, PBUF_RAM);
-            if (p != NULL) {
-                /* Copy ethernet frame into pbuf */
-                pbuf_take((struct pbuf*)p, (uint8_t*)rx_frame_buf, (uint32_t)rx_frame_dim);
-                eth_release_rx_buffer();
-                eth_queue.push((struct pbuf*)p);
+        if (p != NULL) {
+            /* Copy ethernet frame into pbuf */
+            pbuf_take((struct pbuf*)p, (uint8_t*)rx_frame_buf, (uint32_t)rx_frame_dim);
+
+            if (ni.input((struct pbuf*)p, &ni) != ERR_OK) {
+                pbuf_free((struct pbuf*)p);
             }
         }
+
+        eth_release_rx_buffer();
     }
+    __enable_irq();
 }
 
 /* -------------------------------------------------------------------------- */
-void CLwipIf::setPendingEthRx()
-{
-    /* -------------------------------------------------------------------------- */
-    pending_eth_rx = true;
-}
-
-/* -------------------------------------------------------------------------- */
-err_t CLwipIf::initEth(struct netif* _ni)
+err_t CEth::init(struct netif* _ni)
 {
     /* -------------------------------------------------------------------------- */
 #if LWIP_NETIF_HOSTNAME
@@ -316,7 +323,7 @@ err_t CLwipIf::initEth(struct netif* _ni)
      * from it if you have to do some checks before sending (e.g. if link
      * is available...) */
     _ni->output = etharp_output;
-    _ni->linkoutput = ouputEth;
+    _ni->linkoutput = CEth::output;
 
     /* set MAC hardware address */
     _ni->hwaddr_len = eth_get_mac_address(_ni->hwaddr);
@@ -328,36 +335,42 @@ err_t CLwipIf::initEth(struct netif* _ni)
     /* don't set NETIF_FLAG_ETHARP if this device is not an ethernet one */
     _ni->flags |= NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;
 
-    /* set the callback function that is called when an ethernet frame is physically
-       received, it is important that the callbacks are set before the initializiation */
-    eth_set_rx_frame_cbk(setPendingEthRx);
-    eth_set_link_on_cbk(ethLinkUp);
-    eth_set_link_off_cbk(ethLinkDown);
-
     return ERR_OK;
 }
 
 /* -------------------------------------------------------------------------- */
-err_t CLwipIf::ouputEth(struct netif* _ni, struct pbuf *p) {
-/* -------------------------------------------------------------------------- */   
-  (void)_ni;
+err_t CEth::output(struct netif* _ni, struct pbuf *p) {
+/* -------------------------------------------------------------------------- */
+    /*
+     * This function is called inside the lwip timeout engine. Since we are working inside
+     * an environment without threads it is required to not lock. For this reason we should
+     * avoid busy waiting and instead discard the transmission. Lwip will handle the retransmission
+     * of the packet.
+     */
+    (void)_ni;
 
-  err_t errval = ERR_OK;
-  uint16_t tx_buf_dim = 0;
-  uint8_t *tx_buf = eth_get_tx_buffer(&tx_buf_dim);
-  assert (p->tot_len <= tx_buf_dim);
+    err_t errval = ERR_OK;
 
-    uint16_t bytes_actually_copied = pbuf_copy_partial(p, tx_buf, p->tot_len, 0);
-    if (bytes_actually_copied > 0) {
-        if (!eth_output(tx_buf, bytes_actually_copied)) {
+    if(eth_output_can_transimit()) {
+        uint16_t tx_buf_dim = 0;
+
+        // TODO analyze the race conditions that may arise from sharing a non synchronized buffer
+        uint8_t *tx_buf = eth_get_tx_buffer(&tx_buf_dim);
+        assert (p->tot_len <= tx_buf_dim);
+
+        uint16_t bytes_actually_copied = pbuf_copy_partial(p, tx_buf, p->tot_len, 0);
+
+        if (bytes_actually_copied > 0 && !eth_output(tx_buf, bytes_actually_copied)) {
             errval = ERR_IF;
         }
+    } else {
+        errval = ERR_INPROGRESS;
     }
     return errval;
 }
 
 /* -------------------------------------------------------------------------- */
-err_t CLwipIf::outputWifiStation(struct netif* _ni, struct pbuf *p) {
+err_t CWifiStation::output(struct netif* _ni, struct pbuf *p) {
 /* -------------------------------------------------------------------------- */   
     (void)_ni;
     err_t errval = ERR_IF;
@@ -366,8 +379,8 @@ err_t CLwipIf::outputWifiStation(struct netif* _ni, struct pbuf *p) {
         uint16_t bytes_actually_copied = pbuf_copy_partial(p, buf, p->tot_len, 0);
         if (bytes_actually_copied > 0) {
             int ifn = 0;
-            if (net_ifs[NI_WIFI_STATION] != nullptr) {
-                ifn = net_ifs[NI_WIFI_STATION]->getId();
+            if (CLwipIf::net_ifs[NI_WIFI_STATION] != nullptr) {
+                ifn = CLwipIf::net_ifs[NI_WIFI_STATION]->getId();
             }
 
 #ifdef DEBUG_OUTPUT_DISABLED
@@ -391,7 +404,7 @@ err_t CLwipIf::outputWifiStation(struct netif* _ni, struct pbuf *p) {
 }
 
 /* -------------------------------------------------------------------------- */
-err_t CLwipIf::initWifiStation(struct netif* _ni)
+err_t CWifiStation::init(struct netif* _ni)
 {
     /* -------------------------------------------------------------------------- */
 #if LWIP_NETIF_HOSTNAME
@@ -406,7 +419,7 @@ err_t CLwipIf::initWifiStation(struct netif* _ni)
      * from it if you have to do some checks before sending (e.g. if link
      * is available...) */
     _ni->output = etharp_output;
-    _ni->linkoutput = outputWifiStation;
+    _ni->linkoutput = CWifiStation::output;
 
     /* maximum transfer unit */
     _ni->mtu = 1500;
@@ -422,7 +435,7 @@ err_t CLwipIf::initWifiStation(struct netif* _ni)
 }
 
 /* -------------------------------------------------------------------------- */
-err_t CLwipIf::outputWifiSoftAp(struct netif* _ni, struct pbuf* p)
+err_t CWifiSoftAp::output(struct netif* _ni, struct pbuf* p)
 {
     /* -------------------------------------------------------------------------- */
     (void)_ni;
@@ -434,8 +447,8 @@ err_t CLwipIf::outputWifiSoftAp(struct netif* _ni, struct pbuf* p)
         uint16_t bytes_actually_copied = pbuf_copy_partial(p, buf, p->tot_len, 0);
         if (bytes_actually_copied > 0) {
             int ifn = 0;
-            if (net_ifs[NI_WIFI_SOFTAP] != nullptr) {
-                ifn = net_ifs[NI_WIFI_SOFTAP]->getId();
+            if (CLwipIf::net_ifs[NI_WIFI_SOFTAP] != nullptr) {
+                ifn = CLwipIf::net_ifs[NI_WIFI_SOFTAP]->getId();
             }
 
             if (CEspControl::getInstance().sendBuffer(ESP_AP_IF, ifn, buf, bytes_actually_copied) == ESP_CONTROL_OK) {
@@ -449,7 +462,7 @@ err_t CLwipIf::outputWifiSoftAp(struct netif* _ni, struct pbuf* p)
 }
 
 /* -------------------------------------------------------------------------- */
-err_t CLwipIf::initWifiSoftAp(struct netif* _ni)
+err_t CWifiSoftAp::init(struct netif* _ni)
 {
     /* -------------------------------------------------------------------------- */
 #if LWIP_NETIF_HOSTNAME
@@ -464,7 +477,7 @@ err_t CLwipIf::initWifiSoftAp(struct netif* _ni)
      * from it if you have to do some checks before sending (e.g. if link
      * is available...) */
     _ni->output = etharp_output;
-    _ni->linkoutput = outputWifiSoftAp;
+    _ni->linkoutput = CWifiSoftAp::output;
 
     /* maximum transfer unit */
     _ni->mtu = 1500;
@@ -640,8 +653,8 @@ int CLwipIf::connectToAp(const char* ssid, const char* pwd)
             rv = ESP_CONTROL_OK;
             /* when we get the connection to access point we are sure we are STATION
                and we are connected */
-            if (net_ifs[NI_WIFI_STATION] != nullptr) {
-                net_ifs[NI_WIFI_STATION]->setLinkUp();
+            if (CLwipIf::net_ifs[NI_WIFI_STATION] != nullptr) {
+                CLwipIf::net_ifs[NI_WIFI_STATION]->setLinkUp();
             }
 
       }
@@ -762,28 +775,13 @@ int CLwipIf::resetLowPowerMode()
     return rv;
 }
 
-/* -------------------------------------------------------------------------- */
-struct pbuf* CLwipIf::getEthFrame()
-{
-    /* -------------------------------------------------------------------------- */
-    struct pbuf* rv = nullptr;
-    if (!CLwipIf::eth_queue.empty()) {
-        rv = CLwipIf::eth_queue.front();
-        CLwipIf::eth_queue.pop();
-    }
-    else {
-        CLwipIf::eth_queue = {};
-    }
-    return rv;
-}
-
 #ifdef LWIP_USE_TIMER
 /* -------------------------------------------------------------------------- */
 void CLwipIf::timer_cb(timer_callback_args_t *arg) {
 /*  -------------------------------------------------------------------------- */   
   (void)arg;
   CLwipIf::getInstance().lwip_task();
-} 
+}
 #endif
 
 /* ***************************************************************************
@@ -1288,7 +1286,7 @@ void CEth::begin(IPAddress _ip, IPAddress _gw, IPAddress _nm)
     IP_ADDR4(&nm, _nm[0], _nm[1], _nm[2], _nm[3]);
     IP_ADDR4(&gw, _gw[0], _gw[1], _gw[2], _gw[3]);
 
-    netif_add(&ni, &ip, &nm, &gw, NULL, CLwipIf::initEth, ethernet_input);
+    netif_add(&ni, &ip, &nm, &gw, NULL, CEth::init, ethernet_input);
     netif_set_default(&ni);
 
     if (netif_is_link_up(&ni)) {
@@ -1303,32 +1301,27 @@ void CEth::begin(IPAddress _ip, IPAddress _gw, IPAddress _nm)
     /* Set the link callback function, this function is called on change of link status */
     // netif_set_link_callback(&eth0if, eht0if_link_toggle_cbk);
 #endif /* LWIP_NETIF_LINK_CALLBACK */
+    /*
+     * set the callback function that is called when an ethernet frame is physically
+     * received, it is important that the callbacks are set before the initializiation 
+     */
+    eth_set_rx_frame_cbk(std::bind(&CEth::handleEthRx, this));
+    eth_set_link_on_cbk(std::bind(&CEth::setLinkUp, this));
+    eth_set_link_off_cbk(std::bind(&CEth::setLinkDown, this));
 }
 
 /* -------------------------------------------------------------------------- */
 void CEth::task()
 {
     /* -------------------------------------------------------------------------- */
-    struct pbuf* p = nullptr;
 
     eth_execute_link_process();
-
-    __disable_irq();
-    CLwipIf::ethFrameRx();
-    p = (struct pbuf*)CLwipIf::getInstance().getEthFrame();
-    __enable_irq();
-    if (p != nullptr) {
-
-        if (ni.input((struct pbuf*)p, &ni) != ERR_OK) {
-            pbuf_free((struct pbuf*)p);
-        }
-    }
-    
 
 #if LWIP_DHCP
     static unsigned long dhcp_last_time_call = 0;
     if (dhcp_last_time_call == 0 || millis() - dhcp_last_time_call > DHCP_FINE_TIMER_MSECS) {
         dhcp_task();
+        dhcp_last_time_call = millis();
     }
 #endif
 }
@@ -1351,7 +1344,7 @@ void CWifiStation::begin(IPAddress _ip, IPAddress _gw, IPAddress _nm)
     IP_ADDR4(&nm, _nm[0], _nm[1], _nm[2], _nm[3]);
     IP_ADDR4(&gw, _gw[0], _gw[1], _gw[2], _gw[3]);
 
-    netif_add(&ni, &ip, &nm, &gw, NULL, CLwipIf::initWifiStation, ethernet_input);
+    netif_add(&ni, &ip, &nm, &gw, NULL, CWifiStation::init, ethernet_input);
     netif_set_default(&ni);
 
     if (netif_is_link_up(&ni)) {
@@ -1401,6 +1394,7 @@ void CWifiStation::task()
     static unsigned long dhcp_last_time_call = 0;
     if (dhcp_last_time_call == 0 || millis() - dhcp_last_time_call > DHCP_FINE_TIMER_MSECS) {
         dhcp_task();
+        dhcp_last_time_call = millis();
     }
 #endif
 }
@@ -1457,7 +1451,7 @@ void CWifiSoftAp::begin(IPAddress _ip, IPAddress _gw, IPAddress _nm)
     IP_ADDR4(&nm, _nm[0], _nm[1], _nm[2], _nm[3]);
     IP_ADDR4(&gw, _gw[0], _gw[1], _gw[2], _gw[3]);
 
-    netif_add(&ni, &ip, &nm, &gw, NULL, CLwipIf::initWifiSoftAp, ethernet_input);
+    netif_add(&ni, &ip, &nm, &gw, NULL, CWifiSoftAp::init, ethernet_input);
     netif_set_default(&ni);
     if (netif_is_link_up(&ni)) {
         /* When the netif is fully configured this function must be called */
@@ -1477,7 +1471,8 @@ void CWifiSoftAp::begin(IPAddress _ip, IPAddress _gw, IPAddress _nm)
 void CWifiSoftAp::task()
 {
     /* -------------------------------------------------------------------------- */
-    /* get messages and process it  */
+    /* get messages and process it 
+     * TODO change the algorithm and make it similar to WiFiStation */
     uint8_t if_num;
     uint16_t dim;
     uint8_t* buf = nullptr;
@@ -1504,6 +1499,7 @@ void CWifiSoftAp::task()
     static unsigned long dhcp_last_time_call = 0;
     if (dhcp_last_time_call == 0 || millis() - dhcp_last_time_call > DHCP_FINE_TIMER_MSECS) {
         dhcp_task();
+        dhcp_last_time_call = millis();
     }
 #endif
 }

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -11,7 +11,6 @@
 #include "CEspControl.h"
 #include "IPAddress.h"
 #include "EthernetDriver.h"
-#include <queue>
 #include <string>
 #ifdef USE_LWIP_AS_LIBRARY
 #include "lwip/include/lwip/dhcp.h"
@@ -216,6 +215,15 @@ public:
 class CEth : public CNetIf {
     /* -------------------------------------------------------------------------- */
 protected:
+    /*
+     * this function is used to initialize the netif structure of lwip
+     */
+    static err_t init(struct netif* ni);
+
+    /*
+     * This function is passed to lwip and used to send a buffer to the driver in order to transmit it
+     */
+    static err_t output(struct netif* ni, struct pbuf* p);
 public:
     CEth();
     virtual ~CEth();
@@ -229,12 +237,23 @@ public:
         UNUSED(mac);
         return 1;
     }
+
+    virtual void handleEthRx();
 };
 
 /* -------------------------------------------------------------------------- */
 class CWifiStation : public CNetIf {
     /* -------------------------------------------------------------------------- */
 protected:
+    /*
+     * this function is used to initialize the netif structure of lwip
+     */
+    static err_t init(struct netif* ni);
+
+    /*
+     * This function is passed to lwip and used to send a buffer to the driver in order to transmit it
+     */
+    static err_t output(struct netif* ni, struct pbuf* p);
 public:
     CWifiStation();
     virtual ~CWifiStation();
@@ -254,6 +273,16 @@ public:
 /* -------------------------------------------------------------------------- */
 class CWifiSoftAp : public CNetIf {
     /* -------------------------------------------------------------------------- */
+protected:
+    /*
+     * this function is used to initialize the netif structure of lwip
+     */
+    static err_t init(struct netif* ni);
+
+    /*
+     * This function is passed to lwip and used to send a buffer to the driver in order to transmit it
+     */
+    static err_t output(struct netif* ni, struct pbuf* p);
 public:
     CWifiSoftAp();
     virtual ~CWifiSoftAp();
@@ -274,14 +303,14 @@ public:
 class CLwipIf {
     /* -------------------------------------------------------------------------- */
 private:
-    static std::queue<struct pbuf*> eth_queue;
-
     bool eth_initialized;
 
     int dns_num;
     bool willing_to_start_sync_req;
     bool async_requests_ongoing;
 
+    friend CWifiStation;
+    friend CWifiSoftAp;
     static CNetIf* net_ifs[NETWORK_INTERFACES_MAX_NUM];
     static WifiStatus_t wifi_status;
 
@@ -349,23 +378,19 @@ public:
     void addDns(IPAddress aDNSServer);
     IPAddress getDns(int _num = 0);
 
-    /*
-     * these functions are passed to netif_add function as 'init' function for
-     * that network interface
-     */
 
-    static err_t initEth(struct netif* ni);
-    static err_t initWifiStation(struct netif* ni);
-    static err_t initWifiSoftAp(struct netif* ni);
+    // static err_t initEth(struct netif* ni);
+    // static err_t initWifiStation(struct netif* ni);
+    // static err_t initWifiSoftAp(struct netif* ni);
 
     /*
      * these functions are passed to are set to netif->linkoutput function during
      * the execution of the previous init function
      */
 
-    static err_t ouputEth(struct netif* ni, struct pbuf* p);
-    static err_t outputWifiStation(struct netif* netif, struct pbuf* p);
-    static err_t outputWifiSoftAp(struct netif* netif, struct pbuf* p);
+    // static err_t ouputEth(struct netif* ni, struct pbuf* p);
+    // static err_t outputWifiStation(struct netif* netif, struct pbuf* p);
+    // static err_t outputWifiSoftAp(struct netif* netif, struct pbuf* p);
 
     /* when you 'get' a network interface, you get a pointer to one of the pointers
        held by net_ifs array
@@ -380,9 +405,7 @@ public:
 
     static void ethLinkUp();
     static void ethLinkDown();
-    static void ethFrameRx();
 
-    static void setPendingEthRx();
     /* this function set the mac address of the corresponding interface to mac
        and set this value for lwip */
     bool setMacAddress(NetIfType_t type, uint8_t* mac = nullptr);
@@ -414,8 +437,6 @@ public:
     uint8_t getEncryptionType(NetIfType_t type);
 
     int setWifiMode(WifiMode_t mode);
-
-    struct pbuf* getEthFrame();
 
     void lwip_task();
 };


### PR DESCRIPTION
This fix aims to solve issues on ethernet and wifi communication on portenta c33. This required some changes in the structure of the library, in order to avoid wasting memory on temporary queues.