### PR TITLE
Lwip wrapper memory issues

### DIFF
--- a/libraries/SSLClient/src/SSLClient.cpp
+++ b/libraries/SSLClient/src/SSLClient.cpp
@@ -85,6 +85,7 @@ SSLClient::SSLClient(Client* client, String ca_path)
 SSLClient::~SSLClient()
 {
     stop();
+    delete sslclient->client;
     delete sslclient;
 }
 

--- a/libraries/SSLClient/src/SSLClient.h
+++ b/libraries/SSLClient/src/SSLClient.h
@@ -46,7 +46,7 @@ public:
     SSLClient();
     SSLClient(Client* client);
     SSLClient(Client* client, String ca_path);
-    ~SSLClient();
+    virtual ~SSLClient();
 
     void setClient(Client& client);
 

--- a/libraries/lwIpWrapper/src/lwipClient.cpp
+++ b/libraries/lwIpWrapper/src/lwipClient.cpp
@@ -29,6 +29,13 @@ lwipClient::lwipClient(struct tcp_struct* tcpClient)
 
 {
 }
+
+/* -------------------------------------------------------------------------- */
+lwipClient::lwipClient(lwipClient&& c) noexcept
+    :_tcp_client(std::move(c._tcp_client)), _provided_tcp_client(c._provided_tcp_client), _timeout(c._timeout)
+{
+
+}
 /* -------------------------------------------------------------------------- */
 
 /* -------------------------------------------------------------------------- */
@@ -40,6 +47,17 @@ lwipClient::~lwipClient()
         mem_free(_tcp_client); 
     }
 }
+/* -------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+lwipClient& lwipClient::operator=(lwipClient&& c) {
+    this->_tcp_client = std::move(c._tcp_client);
+    this->_provided_tcp_client = c._provided_tcp_client;
+    this->_timeout = c._timeout;
+
+    return *this;
+}
+
 /* -------------------------------------------------------------------------- */
 
 /* -------------------------------------------------------------------------- */

--- a/libraries/lwIpWrapper/src/lwipClient.cpp
+++ b/libraries/lwIpWrapper/src/lwipClient.cpp
@@ -259,7 +259,7 @@ uint8_t lwipClient::connected()
 {
     /* -------------------------------------------------------------------------- */
     uint8_t s = status();
-    return ((available() && (s == TCP_CLOSING)) || (s == TCP_CONNECTED) || (s == TCP_ACCEPTED));
+    return s != TCP_DISCONNECTED && ((available() && (s == TCP_CLOSING)) || (s == TCP_CONNECTED) || (s == TCP_ACCEPTED));
 }
 
 /* -------------------------------------------------------------------------- */
@@ -286,6 +286,13 @@ bool lwipClient::operator==(const lwipClient& rhs)
 {
     /* -------------------------------------------------------------------------- */
     return _tcp_client == rhs._tcp_client && _tcp_client->pcb == rhs._tcp_client->pcb;
+}
+
+/* -------------------------------------------------------------------------- */
+bool lwipClient::operator!=(const lwipClient& rhs)
+{
+    /* -------------------------------------------------------------------------- */
+    return _tcp_client != rhs._tcp_client || _tcp_client->pcb != rhs._tcp_client->pcb;
 }
 
 /* This function is not a function defined by Arduino. This is a function

--- a/libraries/lwIpWrapper/src/lwipClient.cpp
+++ b/libraries/lwIpWrapper/src/lwipClient.cpp
@@ -171,9 +171,13 @@ int lwipClient::read()
     uint8_t b;
     if ((_tcp_client != NULL) && (_tcp_client->data.p != NULL)) {
         __disable_irq();
-        pbuffer_get_data(&(_tcp_client->data), &b, 1);
+        int rv = pbuffer_get_data(&(_tcp_client->data), &b, 1);
         __enable_irq();
-        return b;
+        if(rv == 1) {
+            return b;
+        } else {
+            return -1;
+        }
     }
     // No data available
     return -1;

--- a/libraries/lwIpWrapper/src/lwipClient.cpp
+++ b/libraries/lwIpWrapper/src/lwipClient.cpp
@@ -8,7 +8,7 @@ extern "C" {
 
 /* -------------------------------------------------------------------------- */
 lwipClient::lwipClient()
-    : _tcp_client(NULL)
+    : _tcp_client(NULL), _provided_tcp_client(false)
 {
 }
 /* -------------------------------------------------------------------------- */
@@ -17,15 +17,28 @@ lwipClient::lwipClient()
 sketches but sock is ignored. */
 /* -------------------------------------------------------------------------- */
 lwipClient::lwipClient(uint8_t sock)
-    : _tcp_client(NULL)
+    : _tcp_client(NULL), _provided_tcp_client(false)
+
 {
 }
 /* -------------------------------------------------------------------------- */
 
 /* -------------------------------------------------------------------------- */
 lwipClient::lwipClient(struct tcp_struct* tcpClient)
+    : _tcp_client(tcpClient), _provided_tcp_client(true)
+
 {
-    _tcp_client = tcpClient;
+}
+/* -------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+lwipClient::~lwipClient() 
+{
+    stop();
+
+    if(!_provided_tcp_client) {
+        mem_free(_tcp_client); 
+    }
 }
 /* -------------------------------------------------------------------------- */
 

--- a/libraries/lwIpWrapper/src/lwipClient.h
+++ b/libraries/lwIpWrapper/src/lwipClient.h
@@ -43,10 +43,7 @@ public:
         return bool() != value;
     }
     virtual bool operator==(const lwipClient&);
-    virtual bool operator!=(const lwipClient& rhs)
-    {
-        return !this->operator==(rhs);
-    };
+    virtual bool operator!=(const lwipClient& rhs);
     uint8_t getSocketNumber();
     virtual uint16_t localPort()
     {

--- a/libraries/lwIpWrapper/src/lwipClient.h
+++ b/libraries/lwIpWrapper/src/lwipClient.h
@@ -16,6 +16,7 @@ public:
     lwipClient();
     lwipClient(uint8_t sock);
     lwipClient(struct tcp_struct* tcpClient);
+    virtual ~lwipClient();
 
     uint8_t status();
     virtual int connect(IPAddress ip, uint16_t port);
@@ -68,6 +69,8 @@ public:
 private:
     struct tcp_struct* _tcp_client;
     uint16_t _timeout = 10000;
+
+    const bool _provided_tcp_client;
 };
 
 #endif

--- a/libraries/lwIpWrapper/src/lwipClient.h
+++ b/libraries/lwIpWrapper/src/lwipClient.h
@@ -16,7 +16,10 @@ public:
     lwipClient();
     lwipClient(uint8_t sock);
     lwipClient(struct tcp_struct* tcpClient);
+    lwipClient(lwipClient&& c);
     virtual ~lwipClient();
+
+    lwipClient& operator=(lwipClient&& c);
 
     uint8_t status();
     virtual int connect(IPAddress ip, uint16_t port);
@@ -70,7 +73,7 @@ private:
     struct tcp_struct* _tcp_client;
     uint16_t _timeout = 10000;
 
-    const bool _provided_tcp_client;
+    bool _provided_tcp_client;
 };
 
 #endif

--- a/libraries/lwIpWrapper/src/lwipTypes.h
+++ b/libraries/lwIpWrapper/src/lwipTypes.h
@@ -14,6 +14,7 @@ typedef enum {
     TCP_SENT,
     TCP_ACCEPTED,
     TCP_CLOSING,
+    TCP_DISCONNECTED,
 } tcp_client_states;
 
 /* Struct to store received data */


### PR DESCRIPTION
The lwip wrapper has memory issues that may cause memory leaks and dangling pointers. This PR is the beginning of the work to fix these issues. 

There is an improper memory management in the lwipClient and lwipServer that needs to be taken care of.