### PR TITLE
Fix memory corruption bug

### DIFF
--- a/variants/PORTENTA_C33/tusb_config.h
+++ b/variants/PORTENTA_C33/tusb_config.h
@@ -103,7 +103,7 @@
 
 #define CFG_TUH_MSC              1
 #define CFG_TUH_HUB              1
-#define CFG_TUH_DEVICE_MAX       (3*CFG_TUH_HUB + 1)
+#define CFG_TUH_DEVICE_MAX       (3*CFG_TUH_HUB)
 #define CFG_TUH_ENDPOINT_MAX     8
 #define CFG_TUH_API_EDPT_XFER    1
 


### PR DESCRIPTION
A problem occurs when get_new_address() returns address 5, and that number ends up at this line as dev_addr:

_hcd.ep[dev_addr - 1][dir_in][epn - 1] = num;

in hcd_edpt_open() in hcd_rusb2.c(). It becomes 4 and is then used to index the ep array. There's an assert that checks that the address is below 6, so it passes the assert:

TU_ASSERT(dev_addr < 6);

Then the 4 is used as the first index of the ep array, which is defined like so:

uint8_t ep[4][2][15];

This index may only be 0 to 3, so the array is now indexed outside its bounds. And then num is written to that location, which corrupts memory at random locations.

It can be worked around by lowering the value of CFG_TUH_DEVICE_MAX in the configuration file by one. I've also created an issue for TinyUSB.