### PR TITLE
WiFiS3 - static IP config, fix automatic DNS IP

### DIFF
--- a/libraries/WiFiS3/src/WiFi.cpp
+++ b/libraries/WiFiS3/src/WiFi.cpp
@@ -106,7 +106,7 @@ void CWifi::config(IPAddress local_ip) {
   IPAddress _gw(local_ip[0],local_ip[1], local_ip[2], 1);
   IPAddress _sm(255,255,255,0);
   IPAddress dns(0,0,0,0);
-  return _config(local_ip, _gw, _sm,dns,dns);
+  return _config(local_ip, _gw, _sm, _gw, dns);
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Fixes a bug which I guess was introduced while adopting `void CWifi::config(IPAddress local_ip)` from a copy of

```
void CWifi::config(IPAddress local_ip, IPAddress dns_server) {
/* -------------------------------------------------------------------------- */
   IPAddress _gw(local_ip[0],local_ip[1], local_ip[2], 1);
   IPAddress _sm(255,255,255,0);
   IPAddress dns(0,0,0,0);
   return _config(local_ip, _gw, _sm,dns_server,dns);
}
```