### PR TITLE
WiFiS3/C3 - add legacy wl_enc_type constants aliases

### DIFF
--- a/libraries/WiFiS3/src/WiFiTypes.h
+++ b/libraries/WiFiS3/src/WiFiTypes.h
@@ -20,7 +20,9 @@ typedef enum {
 enum wl_enc_type {
     ENC_TYPE_WEP,
     ENC_TYPE_WPA,
+    ENC_TYPE_TKIP = ENC_TYPE_WPA,
     ENC_TYPE_WPA2,
+    ENC_TYPE_CCMP = ENC_TYPE_WPA2,
     ENC_TYPE_WPA2_ENTERPRISE,
     ENC_TYPE_WPA3,
     ENC_TYPE_NONE,

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -73,7 +73,9 @@ typedef enum {
 enum wl_enc_type {
     ENC_TYPE_WEP,
     ENC_TYPE_WPA,
+    ENC_TYPE_TKIP = ENC_TYPE_WPA,
     ENC_TYPE_WPA2,
+    ENC_TYPE_CCMP = ENC_TYPE_WPA2,
     ENC_TYPE_WPA2_ENTERPRISE,
     ENC_TYPE_WPA3,
     ENC_TYPE_NONE,


### PR DESCRIPTION
previous WiFi libraries used the encryption type names ENC_TYPE_TKIP and ENC_TYPE_CCMP, which are based on the name of the encryption algorithm TKIP for WPA and CCMP for WPA2.

In WiFiS3 and WiFiC3 library constants with the well known marketing names WPA and WPA2 are used for encryption type constants.

this PR adds the legacy constants ENC_TYPE_TKIP and ENC_TYPE_CCMP  as aliases. 

EDIT: for WiFiC3 too