### PR TITLE
WiFiC3 - dnsIP(n) getter added

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -223,6 +223,11 @@ IPAddress CWifi::gatewayIP() {
 }
 
 /* -------------------------------------------------------------------------- */
+IPAddress CWifi::dnsIP(int n) {
+   return CLwipIf::getInstance().getDns(n);
+}
+
+/* -------------------------------------------------------------------------- */
 const char* CWifi::SSID(uint8_t networkItem) {  
    return CLwipIf::getInstance().getSSID(networkItem);
 }

--- a/libraries/WiFi/src/WiFiC3.h
+++ b/libraries/WiFi/src/WiFiC3.h
@@ -136,6 +136,13 @@ public:
      */
    IPAddress gatewayIP();
 
+   /*
+    * Get the DNS server IP address.
+    *
+    * return: DNS server IP address value
+    */
+   IPAddress dnsIP(int n = 0);
+
     /*
      * Return the current SSID associated with the network
      *


### PR DESCRIPTION
WiFiS3 has it, ESP32 has it, it originates in ESP8266WiFi. in WiFiNINA it is approved for merge (merged in fw)

overview of WiFi/Ethernet getters and setters:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#network-interface-getters-and-setters