### PR TITLE
WiFiC3 - STA BSSID getter fix

### DIFF
--- a/libraries/lwIpWrapper/src/CNetIf.cpp
+++ b/libraries/lwIpWrapper/src/CNetIf.cpp
@@ -981,7 +981,7 @@ uint8_t* CLwipIf::getBSSID(NetIfType_t type, uint8_t* bssid)
 {
     /* -------------------------------------------------------------------------- */
     if (type == NI_WIFI_STATION) {
-        CNetUtilities::macStr2macArray(bssid, (const char*)access_point_cfg.out_mac);
+        CNetUtilities::macStr2macArray(bssid, (const char*)access_point_cfg.bssid);
         return bssid;
     } else if (type == NI_WIFI_SOFTAP) {
         CNetUtilities::macStr2macArray(bssid, (const char*)soft_ap_cfg.out_mac);


### PR DESCRIPTION
it returned own MAC. it should return BSSID of the AP it is joined to