### PR TITLE
RTC - Replace Serial.print()s from ISR functions in example Sketches

### DIFF
--- a/libraries/RTC/examples/RTC_AutomaticExample/RTC_AutomaticExample.ino
+++ b/libraries/RTC/examples/RTC_AutomaticExample/RTC_AutomaticExample.ino
@@ -17,6 +17,8 @@
 // Include the RTC library
 #include "RTC.h"
 
+bool alarmFlag = false;
+
 DayOfWeek convertDayOfWeek(String s)
 {
   if (s == String("Mon"))
@@ -139,20 +141,7 @@ RTCTime currentRTCTime()
 }
 
 void alarmCallback() {
-  Serial.println("An alarm was triggered at:");
-  RTCTime currentTime;
-  RTC.getTime(currentTime); 
-  Serial.print(currentTime.getYear());
-  Serial.print("-");
-  Serial.print(Month2int(currentTime.getMonth()));
-  Serial.print("-");
-  Serial.print(currentTime.getDayOfMonth());
-  Serial.print(" ");
-  Serial.print(currentTime.getHour());
-  Serial.print(":");
-  Serial.print(currentTime.getMinutes());
-  Serial.print(":");
-  Serial.println(currentTime.getSeconds());
+ alarmFlag = true;
 }
 
 void setup()
@@ -195,4 +184,21 @@ void setup()
 
 void loop()
 {
+  if(alarmFlag){
+  Serial.println("An alarm was triggered at:");
+  RTCTime currentTime;
+  RTC.getTime(currentTime); 
+  Serial.print(currentTime.getYear());
+  Serial.print("-");
+  Serial.print(Month2int(currentTime.getMonth()));
+  Serial.print("-");
+  Serial.print(currentTime.getDayOfMonth());
+  Serial.print(" ");
+  Serial.print(currentTime.getHour());
+  Serial.print(":");
+  Serial.print(currentTime.getMinutes());
+  Serial.print(":");
+  Serial.println(currentTime.getSeconds());
+  alarmFlag = false;
+  }
 }

--- a/libraries/RTC/examples/Test_RTC/Test_RTC.ino
+++ b/libraries/RTC/examples/Test_RTC/Test_RTC.ino
@@ -14,29 +14,19 @@
 // Define the interrupt pin for LED control during interrupts
 const int LED_ON_INTERRUPT  = 22;
 
+bool periodicFlag = false;
+bool alarmFlag = false;
+
 // Callback function for periodic interrupt
 void periodic_cbk() {
-  static bool clb_st = false;
-
-  // Toggle the LED based on callback state
-  if (clb_st) {
-    digitalWrite(LED_ON_INTERRUPT, HIGH);
-  }
-  else {
-    digitalWrite(LED_ON_INTERRUPT, LOW);
-  }
-
-  clb_st = !clb_st;  // Toggle callback state
-
-  // Print message indicating periodic interrupt
-  Serial.println("PERIODIC INTERRUPT");
-}
-
-void alarm_cbk() {
-  Serial.println("ALARM INTERRUPT");
+  periodicFlag = true;
 }
 
 // Callback function for alarm interrupt
+void alarm_cbk() {
+  alarmFlag = true;
+}
+
 void setup() {
   // Initialize serial communication
   Serial.begin(9600);
@@ -90,6 +80,33 @@ void loop() {
   static bool status = false;
 
   RTCTime currenttime;
+
+  if(periodicFlag){
+    // Print message indicating periodic interrupt
+    Serial.println("PERIODIC INTERRUPT");
+
+    static bool clb_st = false;
+
+    // Toggle the LED based on callback state
+    if (clb_st) {
+      digitalWrite(LED_ON_INTERRUPT, HIGH);
+    }
+    else {
+      digitalWrite(LED_ON_INTERRUPT, LOW);
+    }
+
+    clb_st = !clb_st;  // Toggle callback state
+
+    periodicFlag = false;
+  }
+
+  if(alarmFlag){
+    // Print message indicating alarm interrupt
+    Serial.println("ALARM INTERRUPT");
+
+    alarmFlag = false;
+  }
+
 
   // Check if RTC is running and print status
   if (status) {


### PR DESCRIPTION
Currently some of the RTC examples include Serial.print() calls in callback functions that are triggered by an ISR. This is bad practice because:
- Serial.print() can depend on interrupts, which are disabled while another ISR function is running. 
- ISR functions should be as short and quick as possible.

This PR removes Serial.print() calls from callback functions in the RTC example sketches.

They are replaced by flags and conditional statements in the loops, keeping the callback functions as short as possible. 