### PR TITLE
WiFiC3 - don't start DHCP in begin, if static IP is configured

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -25,7 +25,7 @@ int CWifi::begin(const char* ssid) {
 /* -------------------------------------------------------------------------- */   
    ni = CLwipIf::getInstance().get(NI_WIFI_STATION);
    CLwipIf::getInstance().connectToAp(ssid, nullptr);
-   if(ni != nullptr) {
+   if(ni != nullptr && !_useStaticIp) {
       ni->DhcpStart();
    }
    
@@ -39,7 +39,7 @@ int CWifi::begin(const char* ssid, const char *passphrase) {
    
    ni = CLwipIf::getInstance().get(NI_WIFI_STATION);
    CLwipIf::getInstance().connectToAp(ssid, passphrase); 
-   if(ni != nullptr) {
+   if(ni != nullptr && !_useStaticIp) {
       ni->DhcpStart();
    }
    
@@ -96,6 +96,7 @@ extern uint8_t *IpAddress2uint8(IPAddress a);
 /* -------------------------------------------------------------------------- */
 void CWifi::_config(IPAddress local_ip, IPAddress gateway, IPAddress subnet) {
 /* -------------------------------------------------------------------------- */    
+   _useStaticIp = local_ip != INADDR_NONE;
    if(ni != nullptr) {
       ni->DhcpStop();
       ni->DhcpNotUsed();

--- a/libraries/WiFi/src/WiFiC3.h
+++ b/libraries/WiFi/src/WiFiC3.h
@@ -9,6 +9,7 @@ class CWifi {
 private: 
    void _config(IPAddress local_ip, IPAddress gateway, IPAddress subnet);
    unsigned long _timeout;
+   bool _useStaticIp = false;
    CNetIf *ni;
     
 public:


### PR DESCRIPTION
DHCP was overwriting static IP configuration. This PR solves it. It is done same way as in esp32 and esp8266 WiFi library, which too use LwIP .  
It allows to return to DHCP with `config(0)`