### PR TITLE
WiFiS3 - macAddress() return normal bytes ordering

### DIFF
--- a/libraries/WiFiS3/examples/ConnectWithWPA/ConnectWithWPA.ino
+++ b/libraries/WiFiS3/examples/ConnectWithWPA/ConnectWithWPA.ino
@@ -100,14 +100,14 @@ void printCurrentNet() {
 }
 
 void printMacAddress(byte mac[]) {
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
     if (mac[i] < 16) {
       Serial.print("0");
     }
     Serial.print(mac[i], HEX);
-    if (i > 0) {
-      Serial.print(":");
-    }
   }
   Serial.println();
 }

--- a/libraries/WiFiS3/examples/ScanNetworks/ScanNetworks.ino
+++ b/libraries/WiFiS3/examples/ScanNetworks/ScanNetworks.ino
@@ -5,7 +5,7 @@
   connect to any network, so no encryption scheme is specified.
 
   Circuit:
-   * Board with NINA module (Arduino MKR WiFi 1010, MKR VIDOR 4000 and Uno WiFi Rev.2)
+   * Uno R4 WiFi
 
   created 13 July 2010
   by dlf (Metodo2 srl)
@@ -108,14 +108,14 @@ void printEncryptionType(int thisType) {
 
 
 void printMacAddress(byte mac[]) {
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
     if (mac[i] < 16) {
       Serial.print("0");
     }
     Serial.print(mac[i], HEX);
-    if (i > 0) {
-      Serial.print(":");
-    }
   }
   Serial.println();
 }

--- a/libraries/WiFiS3/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/libraries/WiFiS3/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -6,7 +6,7 @@
   BSSID and WiFi channel are printed
 
   Circuit:
-  * Board with NINA module (Arduino MKR WiFi 1010, MKR VIDOR 4000 and Uno WiFi Rev.2)
+  * Uno R4 WiFi
 
   This example is based on ScanNetworks
 
@@ -130,14 +130,14 @@ void print2Digits(byte thisByte) {
 }
 
 void printMacAddress(byte mac[]) {
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
     if (mac[i] < 16) {
       Serial.print("0");
     }
     Serial.print(mac[i], HEX);
-    if (i > 0) {
-      Serial.print(":");
-    }
   }
   Serial.println();
 }

--- a/libraries/WiFiS3/src/WiFi.cpp
+++ b/libraries/WiFiS3/src/WiFi.cpp
@@ -4,12 +4,6 @@ using namespace std;
 
 /* -------------------------------------------------------------------------- */
 CWifi::CWifi() : _timeout(50000){
-   mac[0] = 0;
-   mac[1] = 0;
-   mac[2] = 0;
-   mac[3] = 0;
-   mac[4] = 0;
-   mac[5] = 0;
 }
 /* -------------------------------------------------------------------------- */
 
@@ -242,19 +236,14 @@ uint8_t* CWifi::macAddress(uint8_t* _mac) {
   if(modem.write(string(PROMPT(_MODE)),res, "%s" , CMD_READ(_MODE)))  {
       if(atoi(res.c_str()) == 1) {
          if(modem.write(string(PROMPT(_MACSTA)),res, "%s" , CMD_READ(_MACSTA)))  {
-            macStr2macArray(mac, res.c_str());
+            macStr2macArray(_mac, res.c_str());
          }
       }
       else if(atoi(res.c_str()) == 2) {
          if(modem.write(string(PROMPT(_MACSOFTAP)),res, "%s" , CMD_READ(_MACSOFTAP)))  {
-            macStr2macArray(mac, res.c_str());
+            macStr2macArray(_mac, res.c_str());
          }
       }
-   }
-
-   for(int i = 0; i < 6; i++) 
-   {
-      _mac[i] = mac[5 - i];
    }
 
    return _mac;

--- a/libraries/WiFiS3/src/WiFi.h
+++ b/libraries/WiFiS3/src/WiFi.h
@@ -33,7 +33,6 @@ class CWifi {
 private: 
    void _config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2);
    unsigned long _timeout;
-   uint8_t mac[6];
    std::vector<CAccessPoint> access_points;
    std::string ssid;
    std::string apssid;


### PR DESCRIPTION
The firmware of the first WiFi library returned the MAC address in reversed ordering. It was fixed in examples and not in the `macAddress` method. Since then every WiFi library by Arduino reverses the MAC address in `macAddress` to reversed ordering and some reverse BSSID too. Then the examples print it reversed.

Why continue with this in new libraries? 

here BSSID was not reversed so examples printed it reversed.

overview of WiFi/Ethernet getters and setters:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#network-interface-getters-and-setters
