### PR TITLE
WiFiC3 - macAddress() return normal bytes ordering

### DIFF
--- a/libraries/WiFi/examples/ConnectWithWPA/ConnectWithWPA.ino
+++ b/libraries/WiFi/examples/ConnectWithWPA/ConnectWithWPA.ino
@@ -97,14 +97,14 @@ void printCurrentNet() {
 }
 
 void printMacAddress(byte mac[]) {
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
     if (mac[i] < 16) {
       Serial.print("0");
     }
     Serial.print(mac[i], HEX);
-    if (i > 0) {
-      Serial.print(":");
-    }
   }
   Serial.println();
 }

--- a/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
+++ b/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
@@ -5,7 +5,7 @@
  connect to any network, so no encryption scheme is specified.
 
  Circuit:
- * Board with NINA module (Arduino MKR WiFi 1010, MKR VIDOR 4000 and Uno WiFi Rev.2)
+ * Portenta C33
 
  created 13 July 2010
  by dlf (Metodo2 srl)
@@ -108,14 +108,14 @@ void printEncryptionType(int thisType) {
 }
 
 void printMacAddress(byte mac[]) {
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
     if (mac[i] < 16) {
       Serial.print("0");
     }
     Serial.print(mac[i], HEX);
-    if (i > 0) {
-      Serial.print(":");
-    }
   }
   Serial.println();
 }

--- a/libraries/WiFi/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/libraries/WiFi/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -6,7 +6,7 @@
   BSSID and WiFi channel are printed
 
   Circuit:
-  * Board with NINA module (Arduino MKR WiFi 1010, MKR VIDOR 4000 and Uno WiFi Rev.2)
+  * Portenta C33
 
   This example is based on ScanNetworks
 
@@ -130,14 +130,14 @@ void print2Digits(byte thisByte) {
 }
 
 void printMacAddress(byte mac[]) {
-  for (int i = 5; i >= 0; i--) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
     if (mac[i] < 16) {
       Serial.print("0");
     }
     Serial.print(mac[i], HEX);
-    if (i > 0) {
-      Serial.print(":");
-    }
   }
   Serial.println();
 }

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -172,12 +172,6 @@ uint8_t* CWifi::macAddress(uint8_t* mac) {
 /* -------------------------------------------------------------------------- */   
    if(ni != nullptr) {
       if(ni->getMacAddress(mac) == WL_MAC_ADDR_LENGTH) {
-         // internal mac address representation is inverted
-         for (int i = 0; i<3; i++) {
-            auto tmp = mac[i];
-            mac[i] = mac[5-i];
-            mac[5-i] = tmp;
-         }
          return mac;
       }
    }


### PR DESCRIPTION
The firmware of the first WiFi library returned the MAC address in reversed ordering. It was fixed in examples and not in the `macAddress` method. Since then every WiFi library by Arduino reverses the MAC address in `macAddress` to reversed ordering and some reverse BSSID too. Then the examples print it reversed.

Why continue with this in new libraries? 

here BSSID was not reversed so examples printed it reversed.

overview of WiFi/Ethernet getters and setters:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#network-interface-getters-and-setters