### PR TITLE
Fix: provide include path to where the API folder is stored.

### DIFF
--- a/libraries/Arduino_CAN/extras/test/CMakeLists.txt
+++ b/libraries/Arduino_CAN/extras/test/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.8)
 project(can-test)
 ##########################################################################
 include_directories(../../src)
+include_directories(../../../../cores/arduino)
 include_directories(external/catch2/v2.13.10/include)
 ##########################################################################
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Running the Arduino_CAN unit tests fails otherwise.