### PR TITLE
Allow Wire to switch from master to slave and vice versa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .idea
+compile_commands.json
+.clangd
+.cache/
 cores/arduino/mydebug.cpp
 libraries/Storage/.development
 cores/arduino/mydebug.cpp.donotuse

--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -683,7 +683,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         *(irq_ptr + scfg->txi_irq) = (uint32_t)iic_slave_txi_isr;
         *(irq_ptr + scfg->rxi_irq) = (uint32_t)iic_slave_rxi_isr;
         *(irq_ptr + scfg->tei_irq) = (uint32_t)iic_slave_tei_isr;
-        *(irq_ptr + scfg->eri_irq) = (uint32_t)iic_slave_tei_isr;
+        *(irq_ptr + scfg->eri_irq) = (uint32_t)iic_slave_eri_isr;
         R_BSP_IrqEnable (scfg->txi_irq);
         R_BSP_IrqEnable (scfg->rxi_irq);
         R_BSP_IrqEnable (scfg->tei_irq);

--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -561,35 +561,34 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
         i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
         i2c_slave_cfg_t *scfg = (i2c_slave_cfg_t *)p_cfg->scfg;
-        uint8_t hw_channel = p_cfg->hw_channel;
         mcfg->ipl = I2C_MASTER_PRIORITY;
         
         if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
             /* TX interrupt */
             mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
             scfg->txi_irq = (IRQn_Type)last_interrupt_index;
-            set_iic_tx_link_event(last_interrupt_index, hw_channel);
+            set_iic_tx_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* RX interrupt */
             mcfg->rxi_irq = (IRQn_Type)last_interrupt_index;
             scfg->rxi_irq = (IRQn_Type)last_interrupt_index;
-            set_iic_rx_link_event(last_interrupt_index, hw_channel);
+            set_iic_rx_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* TX ERROR interrupt */
             mcfg->tei_irq = (IRQn_Type)last_interrupt_index;
             scfg->tei_irq = (IRQn_Type)last_interrupt_index;
-            set_iic_tei_link_event(last_interrupt_index, hw_channel);
+            set_iic_tei_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* RX ERROR interrupt */
             mcfg->eri_irq = (IRQn_Type)last_interrupt_index;
             scfg->eri_irq = (IRQn_Type)last_interrupt_index;
-            set_iic_eri_link_event(last_interrupt_index, hw_channel);
+            set_iic_eri_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
         }
@@ -608,27 +607,26 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     else if(p == IRQ_SCI_I2C_MASTER && cfg != NULL) {
         I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
         i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
-        uint8_t hw_channel = p_cfg->hw_channel;
         mcfg->ipl = I2C_MASTER_PRIORITY;
         if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
             /* TX interrupt */
             mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)sci_i2c_txi_isr;
-            set_sci_tx_link_event(last_interrupt_index, hw_channel);
+            set_sci_tx_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* RX interrupt */
             mcfg->rxi_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)sci_i2c_rxi_isr;
-            set_sci_rx_link_event(last_interrupt_index, hw_channel);
+            set_sci_rx_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* TX ERROR interrupt */
             mcfg->tei_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)sci_i2c_tei_isr;
-            set_sci_tei_link_event(last_interrupt_index, hw_channel);
+            set_sci_tei_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
@@ -636,7 +634,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
             #if 0
             mcfg->eri_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)sci_i2c_eri_isr;
-            set_sci_eri_link_event(last_interrupt_index, hw_channel);
+            set_sci_eri_link_event(last_interrupt_index, p_cfg->mcfg->channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
             #endif

--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -556,50 +556,58 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
 #endif
 
 #if WIRE_HOWMANY > 0
+    /* I2C true NOT SCI */
     else if(p == IRQ_I2C_MASTER && cfg != NULL) {
-        I2CIrqMasterReq_t *p_cfg = (I2CIrqMasterReq_t *)cfg;
-        //iic_master_instance_ctrl_t *ctrl = (iic_master_instance_ctrl_t *)p_cfg->ctrl;
-        i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->cfg;
+        I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
+        i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
+        i2c_slave_cfg_t *scfg = (i2c_slave_cfg_t *)p_cfg->scfg;
         uint8_t hw_channel = p_cfg->hw_channel;
         mcfg->ipl = I2C_MASTER_PRIORITY;
+        
         if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
             /* TX interrupt */
             mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_master_txi_isr;
+            scfg->txi_irq = (IRQn_Type)last_interrupt_index;
             set_iic_tx_link_event(last_interrupt_index, hw_channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* RX interrupt */
             mcfg->rxi_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_master_rxi_isr;
+            scfg->rxi_irq = (IRQn_Type)last_interrupt_index;
             set_iic_rx_link_event(last_interrupt_index, hw_channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* TX ERROR interrupt */
             mcfg->tei_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_master_tei_isr;
+            scfg->tei_irq = (IRQn_Type)last_interrupt_index;
             set_iic_tei_link_event(last_interrupt_index, hw_channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
 
             /* RX ERROR interrupt */
             mcfg->eri_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_master_eri_isr;
+            scfg->eri_irq = (IRQn_Type)last_interrupt_index;
             set_iic_eri_link_event(last_interrupt_index, hw_channel);
             R_BSP_IrqCfg((IRQn_Type)last_interrupt_index, I2C_MASTER_PRIORITY, mcfg);
             last_interrupt_index++;
         }
+        
+        *(irq_ptr + mcfg->txi_irq) = (uint32_t)iic_master_txi_isr;
+        *(irq_ptr + mcfg->rxi_irq) = (uint32_t)iic_master_rxi_isr;
+        *(irq_ptr + mcfg->tei_irq) = (uint32_t)iic_master_tei_isr;
+        *(irq_ptr + mcfg->eri_irq) = (uint32_t)iic_master_eri_isr;
+
         R_BSP_IrqEnable (mcfg->txi_irq);
         R_BSP_IrqEnable (mcfg->rxi_irq);
         R_BSP_IrqEnable (mcfg->tei_irq);
         R_BSP_IrqEnable (mcfg->eri_irq);
     }
+    /* I2C SCI MASTER (only) */
     else if(p == IRQ_SCI_I2C_MASTER && cfg != NULL) {
-        I2CIrqMasterReq_t *p_cfg = (I2CIrqMasterReq_t *)cfg;
-        //iic_master_instance_ctrl_t *ctrl = (iic_master_instance_ctrl_t *)p_cfg->ctrl;
-        i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->cfg;
+        I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
+        i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
         uint8_t hw_channel = p_cfg->hw_channel;
         mcfg->ipl = I2C_MASTER_PRIORITY;
         if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
@@ -641,38 +649,45 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         #endif
     }
     else if(p == IRQ_I2C_SLAVE && cfg != NULL) {
-        i2c_slave_cfg_t *p_cfg = (i2c_slave_cfg_t *)cfg;
-        p_cfg->ipl = I2C_SLAVE_PRIORITY;
-        p_cfg->eri_ipl = I2C_SLAVE_PRIORITY;
-        if (p_cfg->txi_irq  == FSP_INVALID_VECTOR) {
+        I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
+        i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
+        i2c_slave_cfg_t *scfg = (i2c_slave_cfg_t *)p_cfg->scfg;
+        scfg->ipl = I2C_SLAVE_PRIORITY;
+        scfg->eri_ipl = I2C_SLAVE_PRIORITY;
+        
+        if (scfg->txi_irq  == FSP_INVALID_VECTOR) {
             /* TX interrupt */
-            p_cfg->txi_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_slave_txi_isr;
-            set_iic_tx_link_event(last_interrupt_index, p_cfg->channel);
+            mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
+            scfg->txi_irq = (IRQn_Type)last_interrupt_index;
+            set_iic_tx_link_event(last_interrupt_index, scfg->channel);
             last_interrupt_index++;
 
             /* RX interrupt */
-            p_cfg->rxi_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_slave_rxi_isr;
-            set_iic_rx_link_event(last_interrupt_index, p_cfg->channel);
+            scfg->rxi_irq = (IRQn_Type)last_interrupt_index;
+            mcfg->rxi_irq = (IRQn_Type)last_interrupt_index;
+            set_iic_rx_link_event(last_interrupt_index, scfg->channel);
             last_interrupt_index++;
 
             /* TEI interrupt */
-            p_cfg->tei_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_slave_tei_isr;
-            set_iic_tei_link_event(last_interrupt_index, p_cfg->channel);
+            scfg->tei_irq = (IRQn_Type)last_interrupt_index;
+            mcfg->tei_irq = (IRQn_Type)last_interrupt_index;
+            set_iic_tei_link_event(last_interrupt_index, scfg->channel);
             last_interrupt_index++;
 
             /* ERI interrupt */
-            p_cfg->eri_irq = (IRQn_Type)last_interrupt_index;
-            *(irq_ptr + last_interrupt_index) = (uint32_t)iic_slave_eri_isr;
-            set_iic_eri_link_event(last_interrupt_index, p_cfg->channel);
+            scfg->eri_irq = (IRQn_Type)last_interrupt_index;
+            mcfg->eri_irq = (IRQn_Type)last_interrupt_index;
+            set_iic_eri_link_event(last_interrupt_index, scfg->channel);
             last_interrupt_index++;
         }
-        R_BSP_IrqEnable (p_cfg->txi_irq);
-        R_BSP_IrqEnable (p_cfg->rxi_irq);
-        R_BSP_IrqEnable (p_cfg->tei_irq);
-        R_BSP_IrqEnable (p_cfg->eri_irq);
+        *(irq_ptr + scfg->txi_irq) = (uint32_t)iic_slave_txi_isr;
+        *(irq_ptr + scfg->rxi_irq) = (uint32_t)iic_slave_rxi_isr;
+        *(irq_ptr + scfg->tei_irq) = (uint32_t)iic_slave_tei_isr;
+        *(irq_ptr + scfg->eri_irq) = (uint32_t)iic_slave_tei_isr;
+        R_BSP_IrqEnable (scfg->txi_irq);
+        R_BSP_IrqEnable (scfg->rxi_irq);
+        R_BSP_IrqEnable (scfg->tei_irq);
+        R_BSP_IrqEnable (scfg->eri_irq);
 
     }
 #endif

--- a/cores/arduino/IRQManager.h
+++ b/cores/arduino/IRQManager.h
@@ -77,7 +77,6 @@ typedef struct rtc_irq {
 typedef struct i2c_irq_req {
     i2c_master_cfg_t *mcfg;
     i2c_slave_cfg_t  *scfg;
-    uint8_t hw_channel;    // needed for SCI
 } I2CIrqReq_t;
 #endif
 

--- a/cores/arduino/IRQManager.h
+++ b/cores/arduino/IRQManager.h
@@ -74,18 +74,11 @@ typedef struct rtc_irq {
 #include "r_iic_master.h"
 #include "r_iic_slave.h"
 
-typedef struct i2c_master_irq {
-    iic_master_instance_ctrl_t *ctrl;
-    i2c_master_cfg_t *cfg;
-    uint8_t hw_channel;
-
-} I2CIrqMasterReq_t;
-
-typedef struct i2c_slave_irq {
-    iic_slave_instance_ctrl_t *ctrl;
-    i2c_slave_cfg_t  *cfg;
-
-} I2CIrqSlaveReq_t;
+typedef struct i2c_irq_req {
+    i2c_master_cfg_t *mcfg;
+    i2c_slave_cfg_t  *scfg;
+    uint8_t hw_channel;    // needed for SCI
+} I2CIrqReq_t;
 #endif
 
 #if SPI_HOWMANY > 0

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -383,12 +383,6 @@ void TwoWire::_begin(void) {
   irq_req.scfg = &s_i2c_cfg;
   
   if(is_master) {    
-      /* see note in the cfg_pins
-           the IRQ manager need to know the HW channel that in case of SCI 
-           peripheral is not the one in the cfg structure but the one in 
-           the Wire channel, so copy it in the request */
-      irq_req.hw_channel = channel;
-      
       if(is_sci) {
         init_ok &= IRQManager::getInstance().addPeripheral(IRQ_SCI_I2C_MASTER,&irq_req);
       }

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -158,6 +158,8 @@ class TwoWire : public arduino::HardwareI2C {
     static void WireSCIMasterCallback(i2c_master_callback_args_t *);
     static void WireMasterCallback(i2c_master_callback_args_t *);
     static void WireSlaveCallback(i2c_slave_callback_args_t *);
+
+    void _begin();
     
     int scl_pin;
     int sda_pin;


### PR DESCRIPTION
This PR solve https://github.com/arduino/ArduinoCore-renesas/issues/180 and supersedes https://github.com/arduino/ArduinoCore-renesas/pull/182.
Basically allow I2C to switch from master to slave and vice versa in a cleaner way (with less changes).