### PR TITLE
OTAUpdate: do not use Error enum to return error codes

### DIFF
--- a/libraries/OTAUpdate/examples/OTA/OTA.ino
+++ b/libraries/OTAUpdate/examples/OTA/OTA.ino
@@ -54,15 +54,14 @@ void setup() {
 
   printWiFiStatus();
 
-  OTAUpdate::Error ret = OTAUpdate::Error::None;
-  ret = ota.begin("/update.bin");
-  if(ret != OTAUpdate::Error::None) {
+  int ret = ota.begin("/update.bin");
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.begin() error: ");
     Serial.println((int)ret);
     return;
   }
   ret = ota.setCACert(root_ca);
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.setCACert() error: ");
     Serial.println((int)ret);
     return;
@@ -74,14 +73,14 @@ void setup() {
     return;
   }
   ret = ota.verify();
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.verify() error: ");
     Serial.println((int)ret);
     return;
   }
 
   ret = ota.update("/update.bin");
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.update() error: ");
     Serial.println((int)ret);
     return;

--- a/libraries/OTAUpdate/examples/WiFiFirmwareOTA/WiFiFirmwareOTA.ino
+++ b/libraries/OTAUpdate/examples/WiFiFirmwareOTA/WiFiFirmwareOTA.ino
@@ -64,15 +64,14 @@ void setup() {
 
   printWiFiStatus();
 
-  OTAUpdate::Error ret = OTAUpdate::Error::None;
-  ret = ota.begin();
-  if(ret != OTAUpdate::Error::None) {
+  int ret = ota.begin();
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.begin() error: ");
     Serial.println((int)ret);
     return;
   }
   ret = ota.setCACert(root_ca);
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.setCACert() error: ");
     Serial.println((int)ret);
     return;
@@ -84,19 +83,19 @@ void setup() {
     return;
   }
   ret = ota.verify();
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.verify() error: ");
     Serial.println((int)ret);
     return;
   }
   ret = ota.update();
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.update() error: ");
     Serial.println((int)ret);
     return;
   }
   ret = ota.reset();
-  if(ret != OTAUpdate::Error::None) {
+  if(ret != OTAUpdate::OTA_ERROR_NONE) {
     Serial.println("ota.reset() error: ");
     Serial.println((int)ret);
     return;

--- a/libraries/OTAUpdate/src/OTAUpdate.cpp
+++ b/libraries/OTAUpdate/src/OTAUpdate.cpp
@@ -22,35 +22,35 @@ using namespace std;
 
 OTAUpdate::OTAUpdate() {}
 
-OTAUpdate::Error OTAUpdate::setCACert(const char* root_ca) {
+int OTAUpdate::setCACert(const char* root_ca) {
   string res = "";
   if ( root_ca != nullptr && strlen(root_ca) > 0) {
     modem.write_nowait(string(PROMPT(_OTA_SETCAROOT)), res, "%s%d\r\n", CMD_WRITE(_OTA_SETCAROOT), strlen(root_ca));
     if(modem.passthrough((uint8_t *)root_ca, strlen(root_ca))) {
-      return Error::None;
+      return static_cast<int>(Error::None);
     }
-    return Error::Modem;
+    return static_cast<int>(Error::Modem);
   }
-  return Error::Library;
+  return static_cast<int>(Error::Library);
 }
 
-OTAUpdate::Error OTAUpdate::begin() {
+int OTAUpdate::begin() {
   string res = "";
   if (modem.write(string(PROMPT(_OTA_BEGIN)), res, "%s", CMD(_OTA_BEGIN))) {
-    return static_cast<OTAUpdate::Error>(atoi(res.c_str()));
+    return atoi(res.c_str());
   }
-  return Error::Modem;
+  return static_cast<int>(Error::Modem);
 }
 
-OTAUpdate::Error OTAUpdate::begin(const char* file_path) {
+int OTAUpdate::begin(const char* file_path) {
   string res = "";
   if ( file_path != nullptr && strlen(file_path) > 0) {
     if (modem.write(string(PROMPT(_OTA_BEGIN)), res, "%s%s\r\n", CMD_WRITE(_OTA_BEGIN), file_path)) {
-      return static_cast<OTAUpdate::Error>(atoi(res.c_str()));
+      return atoi(res.c_str());
     }
-    return Error::Modem;
+    return static_cast<int>(Error::Modem);
   }
-  return Error::Library;
+  return static_cast<int>(Error::Library);
 }
 
 int OTAUpdate::download(const char* url) {
@@ -87,37 +87,37 @@ int OTAUpdate::download(const char* url, const char* file_path) {
   return ret;
 }
 
-OTAUpdate::Error OTAUpdate::verify() {
+int OTAUpdate::verify() {
   string res = "";
   if (modem.write(string(PROMPT(_OTA_VERIFY)), res, "%s", CMD(_OTA_VERIFY))) {
-    return static_cast<OTAUpdate::Error>(atoi(res.c_str()));
+    return atoi(res.c_str());
   }
-  return Error::Modem;
+  return static_cast<int>(Error::Modem);
 }
 
-OTAUpdate::Error OTAUpdate::update() {
+int OTAUpdate::update() {
   string res = "";
   if (modem.write(string(PROMPT(_OTA_UPDATE)), res, "%s", CMD(_OTA_UPDATE))) {
-    return static_cast<OTAUpdate::Error>(atoi(res.c_str()));
+    return atoi(res.c_str());
   }
-  return Error::Modem;
+  return static_cast<int>(Error::Modem);
 }
 
-OTAUpdate::Error OTAUpdate::update(const char* file_path) {
+int OTAUpdate::update(const char* file_path) {
   string res = "";
   if ( file_path != nullptr && strlen(file_path) > 0) {
     if (modem.write(string(PROMPT(_OTA_UPDATE)), res, "%s%s\r\n", CMD_WRITE(_OTA_UPDATE), file_path)) {
-      return Error::None;
+      return atoi(res.c_str());
     }
-    return Error::Modem;
+    return static_cast<int>(Error::Modem);
   }
-  return Error::Library;
+  return static_cast<int>(Error::Library);
 }
 
-OTAUpdate::Error OTAUpdate::reset() {
+int OTAUpdate::reset() {
   string res = "";
   if (modem.write(string(PROMPT(_OTA_RESET)), res, "%s", CMD(_OTA_RESET))) {
-    return Error::None;
+    return static_cast<int>(Error::None);
   }
-  return Error::Modem;
+  return static_cast<int>(Error::Modem);
 }

--- a/libraries/OTAUpdate/src/OTAUpdate.h
+++ b/libraries/OTAUpdate/src/OTAUpdate.h
@@ -28,35 +28,24 @@ class OTAUpdate {
 
 public:
 
-  enum class Error:  int {
-    None                 =  0,
-    StorageConfig        = -1,
-    NoOtaStorage         = -2,
-    OtaStorageInit       = -3,
-    OtaStorageEnd        = -4,
-    UrlParseError        = -5,
-    ServerConnectError   = -6,
-    HttpHeaderError      = -7,
-    ParseHttpHeader      = -8,
-    OtaHeaderLength      = -9,
-    OtaHeaderCrc         = -10,
-    OtaHeaderMagicNumber = -11,
-    OtaDownload          = -12,
-    OtaFlash             = -13,
-    Library              = -14,
-    Modem                = -15,
+  enum class Error: int {
+    None      =  0,
+    Library   = -25,
+    Modem     = -26,
   };
 
+  constexpr static const int OTA_ERROR_NONE = static_cast<int>(Error::None);
+
   OTAUpdate();
-  OTAUpdate::Error setCACert(const char* root_ca);
-  OTAUpdate::Error begin();
-  OTAUpdate::Error begin(const char* file_path);
+  int setCACert(const char* root_ca);
+  int begin();
+  int begin(const char* file_path);
   int download(const char* url);
   int download(const char* url, const char* file_path);
-  OTAUpdate::Error verify();
-  OTAUpdate::Error update();
-  OTAUpdate::Error update(const char* file_path);
-  OTAUpdate::Error reset();
+  int verify();
+  int update();
+  int update(const char* file_path);
+  int reset();
 
 };
 


### PR DESCRIPTION
In this way if an error code changes in the wifi firmware there is no need to change this library