### PR TITLE
LwipWrapper - let the user manage DNS servers

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -60,15 +60,22 @@ int CEthernet::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IP
 
   /* If there is a local DHCP informs it of our manual IP configuration to prevent IP conflict */
   ni->DhcpNotUsed();
-  CLwipIf::getInstance().addDns(dns_server);
+  CLwipIf::getInstance().setDns(0, dns_server);
   return 1;
 }
 
 /* -------------------------------------------------------------------------- */
 void CEthernet::setDNS(IPAddress dns_server) {
 /* -------------------------------------------------------------------------- */  
-  CLwipIf::getInstance().addDns(dns_server);
+  CLwipIf::getInstance().setDns(0, dns_server);
 } 
+
+/* -------------------------------------------------------------------------- */
+void CEthernet::setDNS(IPAddress dns_server1, IPAddress dns_server2) {
+/* -------------------------------------------------------------------------- */
+   CLwipIf::getInstance().setDns(0, dns_server1);
+   CLwipIf::getInstance().setDns(1, dns_server2);
+}
 
 /* -------------------------------------------------------------------------- */
 int CEthernet::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout) {

--- a/libraries/Ethernet/src/EthernetC33.h
+++ b/libraries/Ethernet/src/EthernetC33.h
@@ -55,6 +55,7 @@ class CEthernet {
     EthernetHardwareStatus hardwareStatus();
 
     void setDNS(IPAddress dns_server); 
+    void setDNS(IPAddress dns_server1, IPAddress dns_server2);
 
     int disconnect(void);
     int maintain();

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -116,7 +116,7 @@ void CWifi::_config(IPAddress local_ip, IPAddress gateway, IPAddress subnet) {
 void CWifi::config(IPAddress local_ip, IPAddress dns_server) {
 /* -------------------------------------------------------------------------- */   
    config(local_ip);
-   CLwipIf::getInstance().addDns(dns_server);
+   setDNS(dns_server);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -124,27 +124,27 @@ void CWifi::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway) 
 /* -------------------------------------------------------------------------- */   
    IPAddress _nm(255, 255, 255, 0);
    _config(local_ip, gateway, _nm);
-   CLwipIf::getInstance().addDns(dns_server);
+   setDNS(dns_server);
 }
 
 /* -------------------------------------------------------------------------- */
 void CWifi::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet) {
 /* -------------------------------------------------------------------------- */
    _config(local_ip, gateway, subnet);
-   CLwipIf::getInstance().addDns(dns_server);
+   setDNS(dns_server);
 }
 
 /* -------------------------------------------------------------------------- */
 void CWifi::setDNS(IPAddress dns_server1) {
 /* -------------------------------------------------------------------------- */   
-   CLwipIf::getInstance().addDns(dns_server1);
+   CLwipIf::getInstance().setDns(0, dns_server1);
 }
 
 /* -------------------------------------------------------------------------- */
 void CWifi::setDNS(IPAddress dns_server1, IPAddress dns_server2) {
 /* -------------------------------------------------------------------------- */   
-   CLwipIf::getInstance().addDns(dns_server1);
-   CLwipIf::getInstance().addDns(dns_server2);
+   CLwipIf::getInstance().setDns(0, dns_server1);
+   CLwipIf::getInstance().setDns(1, dns_server2);
    
 }
 

--- a/libraries/lwIpWrapper/src/CNetIf.cpp
+++ b/libraries/lwIpWrapper/src/CNetIf.cpp
@@ -51,7 +51,6 @@ static uint8_t Encr2wl_enc(int enc)
 /* -------------------------------------------------------------------------- */
 CLwipIf::CLwipIf()
     : eth_initialized(false)
-    , dns_num(-1)
     , willing_to_start_sync_req(false)
     , async_requests_ongoing(true)
 {
@@ -916,18 +915,17 @@ int CLwipIf::inet2aton(const char* address, IPAddress& result)
 void CLwipIf::beginDns(IPAddress aDNSServer)
 {
     /* -------------------------------------------------------------------------- */
-    addDns(aDNSServer);
+    setDns(0, aDNSServer);
 }
 
 
 
 /* -------------------------------------------------------------------------- */
-void CLwipIf::addDns(IPAddress aDNSServer)
+void CLwipIf::setDns(uint8_t dns_num, IPAddress aDNSServer)
 {
     /* -------------------------------------------------------------------------- */
 #if LWIP_DNS
     ip_addr_t ip;
-    dns_num++;
     /* DNS initialized by DHCP when call dhcp_start() */
     bool dhcp_started = false;
 

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -305,7 +305,6 @@ class CLwipIf {
 private:
     bool eth_initialized;
 
-    int dns_num;
     bool willing_to_start_sync_req;
     bool async_requests_ongoing;
 
@@ -375,7 +374,7 @@ public:
 
     int getHostByName(const char* aHostname, IPAddress& aResult);
     void beginDns(IPAddress aDNSServer);
-    void addDns(IPAddress aDNSServer);
+    void setDns(uint8_t num, IPAddress aDNSServer);
     IPAddress getDns(int _num = 0);
 
     /* when you 'get' a network interface, you get a pointer to one of the pointers


### PR DESCRIPTION
lwip is compiled for only two DNS server entries (DNS_MAX_SERVERS). 
CNetIf attempted to add DNS servers forever with repeated calls for `config` and `setDNS`. and getter `dnsIP(n)` didn't work as expected.
the best way is to let the library user manage the DNS servers for static IP configuration. 

btw: DHCP sets the DNS servers starting from 0