### PR TITLE
WiFiC3 - apply new static IP settings in _config() (a patch way)

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -103,6 +103,7 @@ void CWifi::_config(IPAddress local_ip, IPAddress gateway, IPAddress subnet) {
       IP_ADDR4(&ni->ip, local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
       IP_ADDR4(&ni->gw, gateway[0], gateway[1], gateway[2], gateway[3]);
       IP_ADDR4(&ni->nm, subnet[0], subnet[1], subnet[2], subnet[3]);
+      netif_set_addr(&ni->ni, &ni->ip, &ni->nm, &ni->gw);
    }
    else {
       CNetIf::default_ip = local_ip;


### PR DESCRIPTION
the PR a quick-dirty-patch to show what is missing. 
a proper solution should be done by the maintainer of the library. maybe a `config` or `setAddress` method in `CNetIf`?

discovered and tested with [WiFiTest](https://github.com/JAndrassy/NetApiHelpers/tree/master/examples/WiFiTest)