### PR TITLE
Fix: Increase accuracy of "delay()" routine.

### DIFF
--- a/cores/arduino/time.cpp
+++ b/cores/arduino/time.cpp
@@ -4,8 +4,11 @@
 
 // this file implements the following public funcions: delay, delayMicroseconds, yield, millis, micros
 
-__attribute__((weak)) void delay(uint32_t ms) {
-	R_BSP_SoftwareDelay(ms, BSP_DELAY_UNITS_MILLISECONDS);
+__attribute__((weak)) void delay(uint32_t ms)
+{
+  auto const start = millis();
+  auto const stop = start + ms;
+  while(millis() < stop) yield();
 }
 
 void delayMicroseconds(unsigned int us) {


### PR DESCRIPTION
This fixes #194.

The following measurements were taken using the [Blink](https://github.com/arduino/arduino-examples/blob/main/examples/01.Basics/Blink/Blink.ino) example using a Arduino Uno R4 Minima.

**Before**:

![image](https://github.com/arduino/ArduinoCore-renesas/assets/3931733/a42addcc-75c4-4536-8580-f166323c47d6)

**After**:

![image](https://github.com/arduino/ArduinoCore-renesas/assets/3931733/1bf740ea-23f9-409b-8b07-02dc2084b031)
