### PR TITLE
Provide frequency/duty_cycle API for PwmOut::begin(...).

### DIFF
--- a/cores/arduino/pwm.cpp
+++ b/cores/arduino/pwm.cpp
@@ -90,6 +90,28 @@ bool PwmOut::begin(uint32_t period_width, uint32_t pulse_width, bool raw /*= fal
   return _enabled;
 }
 
+/* -------------------------------------------------------------------------- */
+bool PwmOut::begin(float freq_hz, float duty_perc) {
+/* -------------------------------------------------------------------------- */
+  _enabled = true;
+  int max_index = PINS_COUNT;
+  _enabled &= cfg_pin(max_index);
+
+  if(_enabled) {
+    _enabled &= timer.begin(TIMER_MODE_PWM, (_is_agt) ? AGT_TIMER : GPT_TIMER, timer_channel, freq_hz, duty_perc);
+  }
+
+  if(_enabled) {
+    timer.add_pwm_extended_cfg();
+    timer.enable_pwm_channel(_pwm_channel);
+
+    _enabled &= timer.open();
+    _enabled &= timer.start();
+  }
+
+  return _enabled;
+}
+
 bool PwmOut::period(int ms) {
   return timer.set_period_ms((double)ms);
 }

--- a/cores/arduino/pwm.h
+++ b/cores/arduino/pwm.h
@@ -22,6 +22,7 @@ class PwmOut {
        TIMER_SOURCE_DIV_256
        TIMER_SOURCE_DIV_1024 */
     bool begin(uint32_t period_usec, uint32_t pulse_usec, bool raw = false, timer_source_div_t sd = TIMER_SOURCE_DIV_1);
+    bool begin(float freq_hz, float duty_perc);
     void end();
     bool period(int ms);
     bool pulseWidth(int ms);


### PR DESCRIPTION
This fixes #168 .

A short example sketch to test this could be:

```C++
#include "pwm.h"

PwmOut pwm_freq(3);

void setup()
{
  Serial.begin(9600);
  while (!Serial) { }
  
  if (!pwm_freq.begin(10*1000*1000.0f, 50.0f))
    Serial.println("Error");
}

void loop() {

}
```

1 MHz :heavy_check_mark: 

![image](https://github.com/arduino/ArduinoCore-renesas/assets/3931733/9a11e4b2-c5e5-434f-9f81-e50332542b08)

5 MHz :heavy_check_mark: 

![image](https://github.com/arduino/ArduinoCore-renesas/assets/3931733/c0777140-b55c-492b-b2b5-22501b68e0b4)

10 MHz :heavy_check_mark: 

![image](https://github.com/arduino/ArduinoCore-renesas/assets/3931733/533adf33-a0cb-4132-94f3-9a957a4ce59a)

Although the generated frequency wanders ever more off the desired target. FYI @maidnl .