### PR TITLE
Fix: compilation of "ESP32_Test.ino" fails due to non-existent function "begin".

### DIFF
--- a/libraries/ESPhost/examples/ESP32_TEST/ESP32_TEST.ino
+++ b/libraries/ESPhost/examples/ESP32_TEST/ESP32_TEST.ino
@@ -1,6 +1,9 @@
 #include "CEspControl.h"
 #include "CNetIf.h"
 #include <string>
+#include <vector>
+
+using namespace std;
 
 /* GPIO_LOCAL C33 
    - 0. P010 
@@ -79,7 +82,6 @@ void setup() {
   CEspControl::getInstance().listenForStationDisconnectEvent(stationDisconnectionEvent);
   CEspControl::getInstance().listenForDisconnectionFromSoftApEvent(disconnectionFromSofApEvent);
   
-  CEspControl::getInstance().begin();
 
   
 


### PR DESCRIPTION
I guess the function was needed earlier in the development process but that no longer seems to be the case. Also doing some small other changes in order to get the sketch to compile.

Compilation/upload on Portenta C33 via
```bash
arduino-cli compile -b arduino-git:renesas:portenta_c33 -v examples/ESP32_TEST -u -p /dev/ttyACM0
```