### PR TITLE
lwipClient - fix mem pool leak 

### DIFF
--- a/libraries/lwIpWrapper/src/lwipClient.h
+++ b/libraries/lwIpWrapper/src/lwipClient.h
@@ -9,6 +9,7 @@
 #include "lwipMem.h"
 #include "lwipTcp.h"
 #include "lwipTypes.h"
+#include <memory>
 
 class lwipClient : public Client {
 
@@ -66,7 +67,7 @@ public:
     using Print::write;
 
 private:
-    struct tcp_struct* _tcp_client;
+    std::shared_ptr<struct tcp_struct> _tcp_client;
     uint16_t _timeout = 10000;
 };
 


### PR DESCRIPTION
fix mem pool leak in lwipClient with shared_ptr with custom deleter.
for lwipClient created from lwipServer the deleter doesn't free the struct. server releases the clients it manages. it would be better if the server used an array of lwipClient objects. then the shared_ptr in them would hold the pointer. maybe in a follow up PR if this is merged.