### PR TITLE
LwipClient - operator bool fix

### DIFF
--- a/libraries/lwIpWrapper/src/lwipClient.cpp
+++ b/libraries/lwIpWrapper/src/lwipClient.cpp
@@ -243,7 +243,7 @@ uint8_t lwipClient::status()
 lwipClient::operator bool()
 {
     /* -------------------------------------------------------------------------- */
-    return (_tcp_client && (_tcp_client->state != TCP_CLOSING));
+    return (_tcp_client != nullptr);
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
op bool should return false only for a 'null' client. a closed client may still have data to read. a Client returned from Server.available() should not fail on the usual bool test if it is closed but has data available.

in 'Arduino language' which doesn't use pointers or references, an empty Client with operator bool returning false is used instead of a NULL pointer. 

Implementations of Client operator bool in other libraries:
the WiFiNINA library
```
WiFiClient::operator bool() {
  return _sock != 255;
}
```
the classic Ethernet library
```
virtual operator bool() { return _sockindex < MAX_SOCK_NUM; }
```
the MbedCore base class for WiFiClient and EthernetClient
```
  operator bool() {
    return sock != nullptr;
  }
```
