### PR TITLE
CNetIf - added config method to apply new static IP settings for WiFi and Ethernet

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -53,9 +53,13 @@ int CEthernet::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway) {
 int CEthernet::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server) {
 /* -------------------------------------------------------------------------- */  
   
-  ni = CLwipIf::getInstance().get(NI_ETHERNET,  local_ip, gateway, subnet);
-  if(ni == nullptr) {
-    return 0;
+  if (ni != nullptr) {
+    ni->config(local_ip, gateway, subnet);
+  } else {
+    ni = CLwipIf::getInstance().get(NI_ETHERNET, local_ip, gateway, subnet);
+    if (ni == nullptr) {
+      return 0;
+    }
   }
 
   /* If there is a local DHCP informs it of our manual IP configuration to prevent IP conflict */

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -98,11 +98,7 @@ void CWifi::_config(IPAddress local_ip, IPAddress gateway, IPAddress subnet) {
 /* -------------------------------------------------------------------------- */    
    _useStaticIp = local_ip != INADDR_NONE;
    if(ni != nullptr) {
-      ni->DhcpStop();
-      ni->DhcpNotUsed();
-      IP_ADDR4(&ni->ip, local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
-      IP_ADDR4(&ni->gw, gateway[0], gateway[1], gateway[2], gateway[3]);
-      IP_ADDR4(&ni->nm, subnet[0], subnet[1], subnet[2], subnet[3]);
+     ni->config(local_ip, gateway, subnet);
    }
    else {
       CNetIf::default_ip = local_ip;

--- a/libraries/lwIpWrapper/src/CNetIf.cpp
+++ b/libraries/lwIpWrapper/src/CNetIf.cpp
@@ -1268,6 +1268,24 @@ void CNetIf::setLinkDown()
     netif_set_down(&ni);
 }
 
+/* -------------------------------------------------------------------------- */
+void CNetIf::config(IPAddress _ip, IPAddress _gw, IPAddress _nm)
+{
+    DhcpStop();
+    DhcpNotUsed();
+
+    IP_ADDR4(&ip, _ip[0], _ip[1], _ip[2], _ip[3]);
+    IP_ADDR4(&nm, _nm[0], _nm[1], _nm[2], _nm[3]);
+    IP_ADDR4(&gw, _gw[0], _gw[1], _gw[2], _gw[3]);
+
+    netif_set_addr(&ni, &ip, &nm, &gw);
+
+    if (netif_is_link_up(&ni)) {
+        netif_set_down(&ni);
+        netif_set_up(&ni);
+    }
+}
+
 /* ########################################################################## */
 /*                      ETHERNET NETWORK INTERFACE CLASS                      */
 /* ########################################################################## */

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -189,6 +189,8 @@ public:
     uint32_t getNmAdd() { return ip4_addr_get_u32(&(ni.netmask)); }
     uint32_t getGwAdd() { return ip4_addr_get_u32(&(ni.gw)); }
 
+    void config(IPAddress _ip, IPAddress _gw, IPAddress _nm);
+
     void setHostname(const char* name)
     {
         memset(hostname, 0x00, MAX_HOSTNAME_DIM);


### PR DESCRIPTION
It was not possible to reconnect to network with a different static IP. IP settings worked only for first invocation of `begin` (applied in CLwipIf::get). 

in CWifi::_config `netif_set_address` call was missing. 
in Ethernet::begin static IP was not applied if `ni` was already initialized.
Now new CNetIf.config does the static IP change for both.

discovered and tested with [WiFiTest](https://github.com/JAndrassy/NetApiHelpers/tree/master/examples/WiFiTest) and [LegacyEthernetTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/LegacyEthernetTest/LegacyEthernetTest.ino)