### PR TITLE
LwipServer - manage connections as LwipClient so a copy always exists for shared_ptr

### DIFF
--- a/libraries/Ethernet/src/EthernetClient.h
+++ b/libraries/Ethernet/src/EthernetClient.h
@@ -8,6 +8,7 @@ class EthernetClient : public lwipClient {
    public:
    EthernetClient() {}
    EthernetClient(struct tcp_struct *tcpClient) : lwipClient(tcpClient) {}
+   EthernetClient(lwipClient& client) : lwipClient(client) {}
 };
 
 #endif

--- a/libraries/Ethernet/src/EthernetServer.h
+++ b/libraries/Ethernet/src/EthernetServer.h
@@ -12,24 +12,8 @@ class EthernetServer : public lwipServer {
    EthernetServer(uint16_t port) : lwipServer(port) {}
 
    EthernetClient available() {
-      accept();
-
-      for (int n = 0; n < MAX_CLIENT; n++) {
-         if (_tcp_client[n] != NULL) {
-            if (_tcp_client[n]->pcb != NULL) {
-               EthernetClient client(_tcp_client[n]);
-               uint8_t s = client.status();
-               if (s == TCP_ACCEPTED) {
-                  if (client.available()) {
-                     return client;
-                  }
-               }
-            }
-         }
-     }
-
-     struct tcp_struct *default_client = NULL;
-     return EthernetClient(default_client);
+     lwipClient client = lwipServer::available();
+     return EthernetClient(client);
    }
 };
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -8,6 +8,7 @@ class WiFiClient : public lwipClient {
    public:
    WiFiClient() {}
    WiFiClient(struct tcp_struct *tcpClient) : lwipClient(tcpClient) {}
+   WiFiClient(lwipClient& client) : lwipClient(client) {}
 };
 
 #endif

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -11,24 +11,8 @@ class WiFiServer : public lwipServer {
    WiFiServer(uint16_t port) : lwipServer(port) {}
 
    WiFiClient available() {
-      accept();
-
-      for (int n = 0; n < MAX_CLIENT; n++) {
-         if (_tcp_client[n] != NULL) {
-            if (_tcp_client[n]->pcb != NULL) {
-               WiFiClient client(_tcp_client[n]);
-               uint8_t s = client.status();
-               if (s == TCP_ACCEPTED) {
-                  if (client.available()) {
-                     return client;
-                  }
-               }
-            }
-         }
-     }
-
-     struct tcp_struct *default_client = NULL;
-     return WiFiClient(default_client);
+     lwipClient client = lwipServer::available();
+     return WiFiClient(client);
    }
 };
 

--- a/libraries/lwIpWrapper/src/lwipClient.h
+++ b/libraries/lwIpWrapper/src/lwipClient.h
@@ -9,6 +9,7 @@
 #include "lwipMem.h"
 #include "lwipTcp.h"
 #include "lwipTypes.h"
+#include <memory>
 
 class lwipClient : public Client {
 
@@ -66,7 +67,7 @@ public:
     using Print::write;
 
 private:
-    struct tcp_struct* _tcp_client;
+    std::shared_ptr<struct tcp_struct> _tcp_client;
     uint16_t _timeout = 10000;
 };
 

--- a/libraries/lwIpWrapper/src/lwipServer.h
+++ b/libraries/lwIpWrapper/src/lwipServer.h
@@ -10,7 +10,7 @@ class lwipServer : public Server {
 protected:
     uint16_t _port;
     struct tcp_struct _tcp_server;
-    struct tcp_struct* _tcp_client[MAX_CLIENT];
+    lwipClient _tcp_client[MAX_CLIENT];
 
     void accept(void);
 

--- a/libraries/lwIpWrapper/src/lwipTcp.cpp
+++ b/libraries/lwIpWrapper/src/lwipTcp.cpp
@@ -1,4 +1,5 @@
 #include "lwipTcp.h"
+#include "lwipClient.h"
 
 #if LWIP_TCP
 static err_t tcp_recv_callback(void* arg, struct tcp_pcb* tpcb, struct pbuf* p, err_t err);
@@ -53,7 +54,7 @@ err_t tcp_accept_callback(void* arg, struct tcp_pcb* newpcb, err_t err)
 {
     err_t ret_err;
     uint8_t accepted;
-    struct tcp_struct** tcpClient = (struct tcp_struct**)arg;
+    lwipClient* tcpClient = (lwipClient*)arg;
 
     /* set priority for the newly accepted tcp connection newpcb */
     tcp_setprio(newpcb, TCP_PRIO_MIN);
@@ -69,8 +70,8 @@ err_t tcp_accept_callback(void* arg, struct tcp_pcb* newpcb, err_t err)
 
             /* Looking for an empty socket */
             for (uint16_t i = 0; i < MAX_CLIENT; i++) {
-                if (tcpClient[i] == NULL) {
-                    tcpClient[i] = client;
+                if (!tcpClient[i]) {
+                    tcpClient[i] = lwipClient(client);
                     accepted = 1;
                     break;
                 }


### PR DESCRIPTION
I made the changes discussed in https://github.com/arduino/ArduinoCore-renesas/pull/207
what do you think?

If this is not merged, I can do a separate PR for the Wifi/Ethernet Client and Server changes. They reduce code duplication. Maybe even the 'facades' could be only a typedef like `typedef lwipClient WiFiClient`, but I am not sure about all consequences of changing a class to a typedef.
