### PR TITLE
Ethernet - standard MACAddress getter with a parameter

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -174,6 +174,10 @@ uint8_t *CEthernet::MACAddress(void) {
   return mac_address;
 }
 
+void CEthernet::MACAddress(uint8_t *mac) {
+  CLwipIf::getInstance().getMacAddress(NI_ETHERNET, mac);
+}
+
 IPAddress CEthernet::localIP() {
   if(ni != nullptr) {
       return IPAddress(ni->getIpAdd());   

--- a/libraries/Ethernet/src/EthernetC33.h
+++ b/libraries/Ethernet/src/EthernetC33.h
@@ -62,6 +62,7 @@ class CEthernet {
 
    
     uint8_t *MACAddress(void);
+    void MACAddress(uint8_t *mac);
     IPAddress localIP();
     IPAddress subnetMask();
     IPAddress gatewayIP();


### PR DESCRIPTION
MACAddress getter as in other Ethernet library

[overview](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#legacy-ethernet-getters-and-setters) of legacy Ethernet specific getters and setters in libraries