### PR TITLE
Ethernet - complete API (setHostname, dnsIP(n), hostByName, ...)

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -65,6 +65,20 @@ int CEthernet::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IP
 }
 
 /* -------------------------------------------------------------------------- */
+void CEthernet::setHostname(const char* hostname) {
+/* -------------------------------------------------------------------------- */
+  if (ni != nullptr) {
+    ni->setHostname(hostname);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void CEthernet::setDnsServerIP(IPAddress dns_server) {
+/* -------------------------------------------------------------------------- */
+  setDNS(dns_server);
+}
+
+/* -------------------------------------------------------------------------- */
 void CEthernet::setDNS(IPAddress dns_server) {
 /* -------------------------------------------------------------------------- */  
   CLwipIf::getInstance().addDns(dns_server);
@@ -178,6 +192,11 @@ void CEthernet::MACAddress(uint8_t *mac) {
   CLwipIf::getInstance().getMacAddress(NI_ETHERNET, mac);
 }
 
+uint8_t* CEthernet::macAddress(uint8_t *mac) {
+  CLwipIf::getInstance().getMacAddress(NI_ETHERNET, mac);
+  return mac;
+}
+
 IPAddress CEthernet::localIP() {
   if(ni != nullptr) {
       return IPAddress(ni->getIpAdd());   
@@ -201,6 +220,16 @@ IPAddress CEthernet::gatewayIP() {
 
 IPAddress CEthernet::dnsServerIP() {
   return CLwipIf::getInstance().getDns();
+}
+
+IPAddress CEthernet::dnsIP(int n) {
+   return CLwipIf::getInstance().getDns(n);
+}
+
+/* -------------------------------------------------------------------------- */
+int CEthernet::hostByName(const char* hostname, IPAddress& result) {
+/* -------------------------------------------------------------------------- */
+   return CLwipIf::getInstance().getHostByName(hostname, result);
 }
 
 CEthernet Ethernet;

--- a/libraries/Ethernet/src/EthernetC33.h
+++ b/libraries/Ethernet/src/EthernetC33.h
@@ -54,6 +54,8 @@ class CEthernet {
     int begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
     EthernetHardwareStatus hardwareStatus();
 
+    void setHostname(const char* hostname);
+    void setDnsServerIP(const IPAddress dns_server); // legacy Ethernet API
     void setDNS(IPAddress dns_server); 
 
     int disconnect(void);
@@ -62,11 +64,15 @@ class CEthernet {
 
    
     uint8_t *MACAddress(void);
-    void MACAddress(uint8_t *mac);
+    void MACAddress(uint8_t *mac); // legacy Ethernet API
+    uint8_t* macAddress(uint8_t* mac);
     IPAddress localIP();
     IPAddress subnetMask();
     IPAddress gatewayIP();
-    IPAddress dnsServerIP();
+    IPAddress dnsServerIP(); // legacy Ethernet API
+    IPAddress dnsIP(int n = 0);
+
+    int hostByName(const char* hostname, IPAddress& result);
 
     friend class EthernetClient;
     friend class EthernetServer;


### PR DESCRIPTION
For legacy Ethernet API, `setDnsServerIP` was missing.
Many Ethernet libraries have now the getters and setters as the WiFi API: `setDNS`, `dnsIP(n)`, `macAddress`
`hostByName` is useful to split blocking `client.connect(gost, port)` into to steps or debug DNS.

`setDNS(dns1, dns2)` is in the PR https://github.com/arduino/ArduinoCore-renesas/pull/200
that PR is important for `dnsServerIP` and `dnsIP(n)` too.

[overview](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#network-interface-getters-and-setters) of API in librarries