### PR TITLE
Ethernet.begin - fix parameters ordering

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -28,29 +28,32 @@ int CEthernet::begin(unsigned long timeout, unsigned long responseTimeout) {
 /* -------------------------------------------------------------------------- */
 int CEthernet::begin(IPAddress local_ip) {
 /* -------------------------------------------------------------------------- */
-  IPAddress subnet(255, 255, 255, 0);
-  return begin(local_ip, subnet);
+  // Assume the DNS server will be the machine on the same network as the local IP
+  // but with last octet being '1'
+  IPAddress dns_server = local_ip;
+  dns_server[3] = 1;
+  return begin(local_ip, dns_server);
 }
 
 /* -------------------------------------------------------------------------- */
-int CEthernet::begin(IPAddress local_ip, IPAddress subnet) {
+int CEthernet::begin(IPAddress local_ip, IPAddress dns_server) {
 /* -------------------------------------------------------------------------- */  
   // Assume the gateway will be the machine on the same network as the local IP
   // but with last octet being '1'
   IPAddress gateway = local_ip;
   gateway[3] = 1;
-  return begin(local_ip, subnet, gateway);
+  return begin(local_ip, dns_server, gateway);
 }
 
 /* -------------------------------------------------------------------------- */
-int CEthernet::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway) {
+int CEthernet::begin(IPAddress local_ip, IPAddress dns_server, IPAddress gateway) {
 /* -------------------------------------------------------------------------- */  
-  // Assume the DNS server will be the same machine than gateway
-  return begin(local_ip, subnet, gateway, gateway);
+  IPAddress subnet(255, 255, 255, 0);
+  return begin(local_ip, dns_server, gateway, subnet);
 }
 
 /* -------------------------------------------------------------------------- */
-int CEthernet::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server) {
+int CEthernet::begin(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet) {
 /* -------------------------------------------------------------------------- */  
   
   ni = CLwipIf::getInstance().get(NI_ETHERNET,  local_ip, gateway, subnet);
@@ -109,7 +112,7 @@ int CEthernet::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_ser
 int CEthernet::begin(uint8_t *mac, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet, unsigned long timeout, unsigned long responseTimeout) {
 /* -------------------------------------------------------------------------- */  
   CLwipIf::getInstance().setMacAddress(NI_ETHERNET, mac_address);
-  return begin(local_ip, subnet, gateway, dns_server);
+  return begin(local_ip, dns_server, gateway, subnet);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/libraries/Ethernet/src/EthernetC33.h
+++ b/libraries/Ethernet/src/EthernetC33.h
@@ -41,9 +41,9 @@ class CEthernet {
     int begin(unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
     EthernetLinkStatus linkStatus();
     int begin(IPAddress local_ip);
-    int begin(IPAddress local_ip, IPAddress subnet);
-    int begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway);
-    int begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server);
+    int begin(IPAddress local_ip, IPAddress dns_server);
+    int begin(IPAddress local_ip, IPAddress dns_server, IPAddress gateway);
+    int begin(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
     // Initialise the Ethernet shield to use the provided MAC address and gain the rest of the
     // configuration through DHCP.
     // Returns 0 if the DHCP configuration failed, and 1 if it succeeded


### PR DESCRIPTION
Author of the STM32Ethernet library decided to change the ordering of the parameters for `begin` without `mac` address parameter. The EthernetC33 library is based on the STM32Ethernet library and the ordering of the parameters was not fixed.

The library is not yet used by many. It requires the Portenta C33 and a Portenta shield with Ethernet PHY module. So lets change the ordering of the parameters as soon as possible.