### PR TITLE
EthernetC33 debugging

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -76,9 +76,8 @@ void CEthernet::setDNS(IPAddress dns_server) {
 /* -------------------------------------------------------------------------- */
 int CEthernet::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout) {
 /* -------------------------------------------------------------------------- */  
-  int ret = (int)CLwipIf::getInstance().setMacAddress(NI_ETHERNET, mac);
-  begin(timeout, responseTimeout);
-  return ret;
+  CLwipIf::getInstance().setMacAddress(NI_ETHERNET, mac);
+  return begin(timeout, responseTimeout);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -111,7 +110,7 @@ int CEthernet::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_ser
 /* -------------------------------------------------------------------------- */
 int CEthernet::begin(uint8_t *mac, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet, unsigned long timeout, unsigned long responseTimeout) {
 /* -------------------------------------------------------------------------- */  
-  CLwipIf::getInstance().setMacAddress(NI_ETHERNET, mac_address);
+  CLwipIf::getInstance().setMacAddress(NI_ETHERNET, mac);
   return begin(local_ip, dns_server, gateway, subnet);
 }
 

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -148,7 +148,7 @@ protected:
     unsigned long dhcp_timeout;
     DhcpSt_t dhcp_st;
     bool dhcp_started;
-    bool dhcp_acquired;
+    volatile bool dhcp_acquired;
     uint8_t _dhcp_lease_state;
     void dhcp_task();
     void dhcp_reset();


### PR DESCRIPTION
the missing `volatile` on `bool dhcp_acquired` in CNetIf.h caused problems for WiFi DHCP too. The waiting for DHCP ended only on timeout, but status() check then was OK because the IP address was set. So WiFi.begin just took long time.

I use Uno R4 to test Renesas Core LwIP networking. For WiFi I have an esp32 with the Hosted firmware on SPI and for Ethernet I replaced the EthernetDriver implementation with one over the W5500 driver (Ethernet 2 shied) from the esp8266 core. So I use `Ethernet.begin` methods with the MAC address parameter where some of this bugs appeared. The missing `restartAsyncRequest();` in `setMacAddress` stopped the periodic task so DHCP then timed out. After that I had in EthernetDriver a buffer smaller than the DHCP packet and the code just hang. It was the the assert in CEth::output).

tested with [LegacyEthernetTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/LegacyEthernetTest/LegacyEthernetTest.ino)

[EthernetDriverW5500.cpp](https://github.com/arduino/ArduinoCore-renesas/files/13759122/EthernetDriverW5500.cpp.txt) should work on Portenta C33 with MKR ETH shield too