### PR TITLE
Return result from ArduinoLEDMatrix::begin() compatible with ArduinoGraphics.

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -175,6 +175,7 @@ public:
         _ledTimer.setup_overflow_irq();
         _ledTimer.open();
         _ledTimer.start();
+        return 1; // ArduinoGraphics::begin() overrides return 1 for success and 0 for failure.
     }
     void next() {
         uint32_t frame[3];


### PR DESCRIPTION
Current implementation returns no value, resulting in annoying compiler warning - change returns value based on ArduinoGraphics docs (https://www.arduino.cc/reference/en/libraries/arduinographics/begin/).