### PR TITLE
ESPHost library - make the example work

### DIFF
--- a/libraries/ESPhost/src/CEspControl.h
+++ b/libraries/ESPhost/src/CEspControl.h
@@ -35,7 +35,6 @@
 #include "CCtrlWrapper.h"
 #include "CEspCommunication.h"
 #include "EspSpiDriver.h"
-#include "CNetIf.h"
 #include "CEspCbks.h"
 #include <string>
 


### PR DESCRIPTION
ESPHost library - make the example work and remove unnecessary dependency to LwipWrapper library and its dependencies.

without the CNetIf.h include only the ESPHost library is used with the example.

with the unnecessary #include "CNetIf.h" it compiles the LwipWrapper library and all its dependencies
```
Using library ESPhost at version 1.0.0 in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/ESPhost 
Using library lwIpWrapper at version 1.0.0 in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/lwIpWrapper 
Using library Ethernet at version 1.0.0 in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/Ethernet 
Using library SSLClient at version 1.1 in folder: /home/duro/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/SSLClient 
Using library SE05X at version 0.0.1 in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/SE05X 
Using library BlockDevices in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/BlockDevices (legacy)
Using library FATFilesystem in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/FATFilesystem (legacy)
Using library Storage in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/Storage (legacy)
Using library Wire in folder: /home/juraj/.arduino15/packages/arduino/hardware/renesas_portenta/1.0.5/libraries/Wire (legacy)
```
