### PR TITLE
Define the `compiler.optimization_flags` allows for specifying the desired optimization level during compilation.

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -14,15 +14,17 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
+compiler.optimization_flags=-Os
+
 compiler.path={build.compiler_path}
 compiler.c.cmd={build.crossprefix}gcc
-compiler.c.flags=-c {compiler.warning_flags} -Os -g3 -nostdlib {build.defines} -MMD -std=gnu11 -mcpu={build.mcu} {build.float-abi} {build.fpu} -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections -fmessage-length=0 -fno-builtin
+compiler.c.flags=-c {compiler.warning_flags} {compiler.optimization_flags} -g3 -nostdlib {build.defines} -MMD -std=gnu11 -mcpu={build.mcu} {build.float-abi} {build.fpu} -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections -fmessage-length=0 -fno-builtin
 compiler.c.elf.cmd={build.crossprefix}g++
 compiler.c.elf.flags=-Wl,--gc-sections --specs=nosys.specs {compiler.warning_flags} -mcpu={build.mcu} {build.float-abi} {build.fpu}
 compiler.S.cmd={build.crossprefix}g++
-compiler.S.flags=-c -g -x assembler-with-cpp -Os -mcpu={build.mcu} {build.float-abi} {build.fpu} -fsigned-char -ffunction-sections -fdata-sections
+compiler.S.flags=-c -g -x assembler-with-cpp {compiler.optimization_flags} -mcpu={build.mcu} {build.float-abi} {build.fpu} -fsigned-char -ffunction-sections -fdata-sections
 compiler.cpp.cmd={build.crossprefix}g++
-compiler.cpp.flags=-c {compiler.warning_flags} -Os -g3 -fno-use-cxa-atexit -fno-rtti -fno-exceptions -MMD -nostdlib {build.defines} -MMD -std=gnu++17 -mcpu={build.mcu} {build.float-abi} {build.fpu} -fsigned-char -ffunction-sections -fdata-sections -fmessage-length=0 -fno-builtin
+compiler.cpp.flags=-c {compiler.warning_flags} {compiler.optimization_flags} -g3 -fno-use-cxa-atexit -fno-rtti -fno-exceptions -MMD -nostdlib {build.defines} -MMD -std=gnu++17 -mcpu={build.mcu} {build.float-abi} {build.fpu} -fsigned-char -ffunction-sections -fdata-sections -fmessage-length=0 -fno-builtin
 compiler.ar.cmd={build.crossprefix}ar
 compiler.ar.flags=rcs
 compiler.ar.extra_flags=

--- a/platform.txt
+++ b/platform.txt
@@ -15,6 +15,8 @@ compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
 compiler.optimization_flags=-Os
+compiler.optimization_flags.release=-Os
+compiler.optimization_flags.debug=-Og
 
 compiler.path={build.compiler_path}
 compiler.c.cmd={build.crossprefix}gcc


### PR DESCRIPTION
This fixes #230 .

This change can be verified by examining the verbose compilation output (`-v`) when compiling a sketch **with** (`--optimize-for-debug`) and **without** optimization for debug turned on.

```bash
arduino-cli compile -b arduino-git:renesas:unor4wifi -v MySketch --optimize-for-debug
```

```bash
arduino-cli compile -b arduino-git:renesas:unor4wifi -v MySketch
```