### PR TITLE
ESPHost - fix softAP password check

### DIFF
--- a/libraries/ESPhost/src/CCtrlWrapper.h
+++ b/libraries/ESPhost/src/CCtrlWrapper.h
@@ -729,8 +729,8 @@ public:
          cfg_ok = false;
       }
 
-      if((strlen((char *)&cfg.pwd) > MAX_PWD_LENGTH) ||
-             ((cfg.encryption_mode == WIFI_AUTH_OPEN) &&
+      if((cfg.encryption_mode != WIFI_AUTH_OPEN) &&
+             ((strlen((char *)&cfg.pwd) > MAX_PWD_LENGTH) ||
               (strlen((char *)&cfg.pwd) < MIN_PWD_LENGTH)) ) {
          /* INVALID BASS*/
          Serial.println("[ERROR]: Invalid password");


### PR DESCRIPTION
SoftAP password length was checked for open network and was not checked for secured