### PR TITLE
WiFiSSLClient: add setEccSlot method to configure client private key and certificate

### DIFF
--- a/libraries/WiFiS3/src/WiFiSSLClient.cpp
+++ b/libraries/WiFiS3/src/WiFiSSLClient.cpp
@@ -36,8 +36,13 @@ int WiFiSSLClient::connect(IPAddress ip, uint16_t port) {
 int WiFiSSLClient::connect(const char* host, uint16_t port) {
 /* -------------------------------------------------------------------------- */
    getSocket();
-   if (!_custom_root) {
+   if (_root_ca != nullptr) {
+      setCACert(_root_ca);
+   } else {
       setCACert();
+   }
+   if ((_ecc_slot != -1) && (_ecc_cert != nullptr) && (_ecc_cert_len != 0)) {
+      setEccSlot(_ecc_slot, _ecc_cert, _ecc_cert_len);
    }
    string res = "";
    if (_connectionTimeout) {
@@ -60,7 +65,7 @@ void WiFiSSLClient::setCACert(const char* root_ca, size_t size) {
    if(size > 0) {
       modem.write_nowait(string(PROMPT(_SETCAROOT)),res, "%s%d,%d\r\n" , CMD_WRITE(_SETCAROOT), _sock, size);
       if(modem.passthrough((uint8_t *)root_ca, size)) {
-         _custom_root = true;
+         _root_ca = root_ca;
       }
    } else {
       modem.write(string(PROMPT(_SETCAROOT)),res, "%s%d\r\n" , CMD_WRITE(_SETCAROOT), _sock);
@@ -75,6 +80,9 @@ void WiFiSSLClient::setEccSlot(int ecc508KeySlot, const byte cert[], int certLen
    if(certLength > 0) {
       modem.write_nowait(string(PROMPT(_SETECCSLOT)),res, "%s%d,%d,%d\r\n" , CMD_WRITE(_SETECCSLOT), _sock, ecc508KeySlot, certLength);
       modem.passthrough((uint8_t *)cert, certLength);
+      _ecc_slot = ecc508KeySlot;
+      _ecc_cert = cert;
+      _ecc_cert_len = certLength;
    }
 }
 

--- a/libraries/WiFiS3/src/WiFiSSLClient.cpp
+++ b/libraries/WiFiS3/src/WiFiSSLClient.cpp
@@ -68,6 +68,17 @@ void WiFiSSLClient::setCACert(const char* root_ca, size_t size) {
 }
 
 /* -------------------------------------------------------------------------- */
+void WiFiSSLClient::setEccSlot(int ecc508KeySlot, const byte cert[], int certLength) {
+/* -------------------------------------------------------------------------- */
+   getSocket();
+   string res = "";
+   if(certLength > 0) {
+      modem.write_nowait(string(PROMPT(_SETECCSLOT)),res, "%s%d,%d,%d\r\n" , CMD_WRITE(_SETECCSLOT), _sock, ecc508KeySlot, certLength);
+      modem.passthrough((uint8_t *)cert, certLength);
+   }
+}
+
+/* -------------------------------------------------------------------------- */
 size_t WiFiSSLClient::write(uint8_t b){
 /* -------------------------------------------------------------------------- */   
    return write(&b, 1);

--- a/libraries/WiFiS3/src/WiFiSSLClient.h
+++ b/libraries/WiFiS3/src/WiFiSSLClient.h
@@ -61,10 +61,14 @@ public:
 
 private:
    int _sock;
-   bool _custom_root = false;
    void getSocket();
    int _read();
    void read_if_needed(size_t s);
+   const char* _root_ca = nullptr;
+   int _ecc_slot = -1;
+   const byte* _ecc_cert = nullptr;
+   int _ecc_cert_len = 0;
+
 };
 
 #endif /* WIFISSLCLIENT_H */

--- a/libraries/WiFiS3/src/WiFiSSLClient.h
+++ b/libraries/WiFiS3/src/WiFiSSLClient.h
@@ -34,6 +34,7 @@ public:
    virtual int connect(IPAddress ip, uint16_t port);
    virtual int connect(const char* host, uint16_t port);
    void setCACert(const char* root_ca = NULL, size_t size = 0); 
+   void setEccSlot(int ecc508KeySlot, const byte cert[], int certLength);
    virtual size_t write(uint8_t);
    virtual size_t write(const uint8_t *buf, size_t size);
    virtual int available();


### PR DESCRIPTION
Apply after #253 

CI fails because new command definition is needed https://github.com/arduino/uno-r4-wifi-usb-bridge/pull/31