### PR TITLE
backtrace: remove spurious file from compiling

### DIFF
--- a/cores/arduino/cm_backtrace/fault_handler/gcc/cmb_fault.S
+++ b/cores/arduino/cm_backtrace/fault_handler/gcc/cmb_fault.S
@@ -26,6 +26,8 @@
  * Created on: 2016-12-16
  */
 
+#ifdef BACKTRACE_SUPPORT
+
 .syntax unified
 .thumb
 .text
@@ -41,3 +43,5 @@ HardFault_Handler:
 
 Fault_Loop:
     BL      Fault_Loop              /* while(1) */
+
+#endif


### PR DESCRIPTION
On C33 and Minima an HardFault was redirected to a nonexistent serial port.