### PR TITLE
Fix: do not randomly clear the first line of the LED matrix.

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -265,10 +265,6 @@ public:
     // display the drawing
     void endDraw() {
       ArduinoGraphics::endDraw();
-      // clear first line (no idea why it gets filled with random bits, probably some math not working fine for super small displays)
-      for (int i = 0; i < canvasWidth; i++) {
-        _canvasBuffer[0][i] = 0;
-      }
       renderBitmap(_canvasBuffer, canvasHeight, canvasWidth);
     }
 


### PR DESCRIPTION
This fixes #259.

Instead the root cause for this issue was within ArduinoGraphics, for a detailed explanation see here: https://github.com/arduino-libraries/ArduinoGraphics/pull/36 .