### PR TITLE
Add a clear() method to the LED matrix library

### DIFF
--- a/libraries/Arduino_LED_Matrix/examples/DisplaySingleFrame/DisplaySingleFrame.ino
+++ b/libraries/Arduino_LED_Matrix/examples/DisplaySingleFrame/DisplaySingleFrame.ino
@@ -34,6 +34,10 @@ void loop() {
   matrix.loadFrame(LEDMATRIX_HEART_BIG);
   delay(500);
 
+  // Turn off the display
+  matrix.clear();
+  delay(1000);
+
   // Print the current value of millis() to the serial monitor
   Serial.println(millis());
 }

--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -248,6 +248,16 @@ public:
         _callBack = callBack;
     }
 
+    void clear() {
+        const uint32_t fullOff[] = {
+        	0x00000000,
+        	0x00000000,
+        	0x00000000
+        };
+        loadFrame(fullOff);
+    }
+
+
 #ifdef MATRIX_WITH_ARDUINOGRAPHICS
     virtual void set(int x, int y, uint8_t r, uint8_t g, uint8_t b) {
       if (y >= canvasHeight || x >= canvasWidth || y < 0 || x < 0) {


### PR DESCRIPTION
This method makes it easy to turn off the matrix.