### PR TITLE
Fix return type of ArduinoLEDMatrix::begin()

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -169,14 +169,19 @@ public:
     void off(size_t pin) {
         turnLed(pin, false);
     }
-    int begin() {
+    bool begin() {
+        bool rv = true;
         uint8_t type;
         uint8_t ch = FspTimer::get_available_timer(type);
+        if(ch == -1) {
+            return false;
+        }
         // TODO: avoid passing "this" argument to remove autoscroll
-        _ledTimer.begin(TIMER_MODE_PERIODIC, type, ch, 10000.0, 50.0, turnOnLedISR, this);
-        _ledTimer.setup_overflow_irq();
-        _ledTimer.open();
-        _ledTimer.start();
+        rv &= _ledTimer.begin(TIMER_MODE_PERIODIC, type, ch, 10000.0, 50.0, turnOnLedISR, this);
+        rv &= _ledTimer.setup_overflow_irq();
+        rv &= _ledTimer.open();
+        rv &= _ledTimer.start();
+        return rv;
     }
     void next() {
         uint32_t frame[3];


### PR DESCRIPTION
While playing around with the LED matrix on my Arduino R4 WiFi I noticed that the function `ArduinoLEDMatrix::begin()` causes a compiler warning:
![image](https://github.com/arduino/ArduinoCore-renesas/assets/46861028/55113ebe-0bbb-44e1-80c0-9e11e1f95222)
(This is what I observe after setting `Preferences -> Compiler Warnings` to `All`)

The reason appears to be very simple: `ArduinoLEDMatrix::begin()` is declared to return an `int`, but never returns anything. I think this is actually ok, since the function has nothing useful it could return. 
Thus I send you this PR to change it's return type from `int` to `void`.