### PR TITLE
define digitalPinHasPWM for UNOWIFIR4 & MINIMA

### DIFF
--- a/variants/MINIMA/pins_arduino.h
+++ b/variants/MINIMA/pins_arduino.h
@@ -90,8 +90,7 @@ static const uint8_t D13 = PIN_D13;
 static const uint8_t D14 = PIN_D14;
 static const uint8_t D15 = PIN_D15;
 
-#define digitalPinHasPWM(p)   ((p) == D3 || (p) == D5 || (p) == D6 || (p) == D9 || (p) == D10 || (p) == D11)
-
+#define digitalPinHasPWM(p) (IS_PIN_PWM(getPinCfgs(p, PIN_CFG_REQ_PWM)[0]))
 // LEDs
 // ----
 #define PIN_LED     (13u)

--- a/variants/MINIMA/pins_arduino.h
+++ b/variants/MINIMA/pins_arduino.h
@@ -90,6 +90,8 @@ static const uint8_t D13 = PIN_D13;
 static const uint8_t D14 = PIN_D14;
 static const uint8_t D15 = PIN_D15;
 
+#define digitalPinHasPWM(p)   ((p) == D3 || (p) == D5 || (p) == D6 || (p) == D9 || (p) == D10 || (p) == D11)
+
 // LEDs
 // ----
 #define PIN_LED     (13u)

--- a/variants/UNOWIFIR4/pins_arduino.h
+++ b/variants/UNOWIFIR4/pins_arduino.h
@@ -90,6 +90,8 @@ static const uint8_t D13 = PIN_D13;
 static const uint8_t D14 = PIN_D14;
 static const uint8_t D15 = PIN_D15;
 
+#define digitalPinHasPWM(p)   ((p) == D3 || (p) == D5 || (p) == D6 || (p) == D9 || (p) == D10 || (p) == D11)
+
 // LEDs
 // ----
 #define PIN_LED     (13u)

--- a/variants/UNOWIFIR4/pins_arduino.h
+++ b/variants/UNOWIFIR4/pins_arduino.h
@@ -90,7 +90,7 @@ static const uint8_t D13 = PIN_D13;
 static const uint8_t D14 = PIN_D14;
 static const uint8_t D15 = PIN_D15;
 
-#define digitalPinHasPWM(p)   ((p) == D3 || (p) == D5 || (p) == D6 || (p) == D9 || (p) == D10 || (p) == D11)
+#define digitalPinHasPWM(p) (IS_PIN_PWM(getPinCfgs(p, PIN_CFG_REQ_PWM)[0]))
 
 // LEDs
 // ----


### PR DESCRIPTION
Defining digitalPinHasPWM will make that those sketches using it from older boards, like UNO R3 or Nano, can also be used with UNO R4, without extra complications for non advanced users (like me).