### PR TITLE
Use correct datatype for return value of FspTimer::get_available_timer()

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -172,7 +172,7 @@ public:
     bool begin() {
         bool rv = true;
         uint8_t type;
-        uint8_t ch = FspTimer::get_available_timer(type);
+        int8_t ch = FspTimer::get_available_timer(type);
         if(ch == -1) {
             return false;
         }


### PR DESCRIPTION
This is a follow-up for #282 :

I missed in my previous PR that the return value from `FspTimer::get_available_timer()` is actually an `int8`, but in Arduino_LED_Matrix.h is stored as `uint8`.
Therefore the following if (added in #282) cannot work as intended:
https://github.com/arduino/ArduinoCore-renesas/blob/2c8dd5744a161e04b304a6105f85b6e616d8256b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h#L175-L178

This PR is to use the correct datatype. Ideally it should have been included in my previous PR.