### PR TITLE
Clear Unused Parameter Warnings in EEPROM examples

### DIFF
--- a/libraries/BlockDevices/HeapBlockDevice.cpp
+++ b/libraries/BlockDevices/HeapBlockDevice.cpp
@@ -105,7 +105,7 @@ bd_size_t HeapBlockDevice::get_erase_size() const
     return _erase_size;
 }
 
-bd_size_t HeapBlockDevice::get_erase_size(bd_addr_t addr) const
+bd_size_t HeapBlockDevice::get_erase_size(__attribute__((unused)) bd_addr_t addr) const
 {
     return _erase_size;
 }

--- a/libraries/BlockDevices/ReadOnlyBlockDevice.cpp
+++ b/libraries/BlockDevices/ReadOnlyBlockDevice.cpp
@@ -24,7 +24,10 @@
 
 int ReadOnlyBlockDevice::open() { return BLOCK_DEVICE_OK; }
 int ReadOnlyBlockDevice::close() { return BLOCK_DEVICE_OK; }
-int ReadOnlyBlockDevice::write(const void *buffer, bd_addr_t addr, bd_size_t size) {return BLOCK_DEVICE_OK;}
+int ReadOnlyBlockDevice::write(__attribute__((unused)) const void *buffer, __attribute__((unused)) bd_addr_t addr, __attribute__((unused)) bd_size_t size) 
+{
+    return BLOCK_DEVICE_OK;
+}
 
 ReadOnlyBlockDevice::ReadOnlyBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -57,12 +60,12 @@ int ReadOnlyBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
     return _bd->read(buffer, addr, size);
 }
 
-int ReadOnlyBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
+int ReadOnlyBlockDevice::program(__attribute__((unused)) const void *buffer, __attribute__((unused)) bd_addr_t addr, __attribute__((unused)) bd_size_t size)
 {
     return BD_ERROR_WRITE_PROTECTED;
 }
 
-int ReadOnlyBlockDevice::erase(bd_addr_t addr, bd_size_t size)
+int ReadOnlyBlockDevice::erase(__attribute__((unused)) bd_addr_t addr, __attribute__((unused)) bd_size_t size)
 {
     return BD_ERROR_WRITE_PROTECTED;
 }


### PR DESCRIPTION
I used one of the EEPROM examples for a test and noticed some unused parameter warnings that were easy to squash.  