### PR TITLE
IRQManager: implement callback based method for custom irq handlers

### DIFF
--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -939,6 +939,31 @@ end_config:
     return rv;
 }
 
+/*
+    The implementer should update the value of last_interrupt once done
+    eg:
+
+    bool config_my_funky_peripheral(unsigned int* last_interrupt, volatile uint32_t *irq_ptr, void* config) {
+        funky_peripheral_cfg_t* cfg = (funky_peripheral_cfg_t*)config;
+        *(irq_ptr + *last_interrupt) = (uint32_t)cfg->irq_callback;
+        cfg->interrupt = *last_interrupt;
+        // increase the interrupt count
+        *last_interrupt++;
+        return true;
+    }
+
+    and then use as:
+
+    funky_peripheral_cfg_t funky_cfg;
+    IRQManager::getInstance().addCustomPeripheral(config_my_funky_peripheral, &funky_cfg);
+*/
+bool IRQManager::addCustomPeripheral(bool (*cb)(unsigned int* last_interrupt, volatile uint32_t *irq_ptr, void* conf), void* conf) {
+    volatile uint32_t *irq_ptr = (volatile uint32_t *)SCB->VTOR;
+    irq_ptr += FIXED_IRQ_NUM;
+
+    return cb(&last_interrupt_index, irq_ptr, conf);
+}
+
 bool IRQManager::set_adc_end_link_event(int li, int ch){
     bool rv = false;
     if (0) {}

--- a/cores/arduino/IRQManager.h
+++ b/cores/arduino/IRQManager.h
@@ -190,6 +190,8 @@ using Irq_f          = void (*)(void);
 class IRQManager {
     public:
     bool addPeripheral(Peripheral_t p, void *cfg);
+    bool addCustomPeripheral(bool (*cb)(unsigned int* last_interrupt, volatile uint32_t *irq_ptr, void* conf), void* conf);
+
     static IRQManager& getInstance();
     
 #ifdef HAS_DMAC


### PR DESCRIPTION
Could fix https://github.com/arduino/ArduinoCore-renesas/issues/310 

I'm not 100% convinced about the freedom <-> ease of use trade off this API should have, in the meantime it's leaning towards the freedom (since the expected audience is not the beginner).

@delta-G  what do you think?

Copying here the test sketch I added to the code
```
void irq_callback() {

}

bool config_my_funky_peripheral(unsigned int* last_interrupt, volatile uint32_t *irq_ptr, void* config) {
  funky_peripheral_cfg_t* cfg = (funky_peripheral_cfg_t*)config;
  *(irq_ptr + *last_interrupt) = (uint32_t)irq_callback;
  cfg->interrupt = *last_interrupt;
  *last_interrupt++;
  return true;
}

funky_peripheral_cfg_t funky_cfg;

void setup() {
  // put your setup code here, to run once:
  IRQManager::getInstance().addCustomPeripheral(config_my_funky_peripheral, &funky_cfg);
}