### PR TITLE
Adding Generic Interrupt function to IRQManager

### DIFF
--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -45,7 +45,7 @@ bool IRQManager::addGenericInterrupt(GenericIrqCfg_t &cfg, Irq_f fnc /*= nullptr
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = false;
     
-    if(cfg.irq == FSP_INVALID_VECTOR) {
+    if((cfg.irq == FSP_INVALID_VECTOR) && (last_interrupt_index < PROG_IRQ_NUM)) {
     	if(fnc != nullptr){
     		R_ICU->IELSR[last_interrupt_index] = cfg.event;
     		*(irq_ptr + last_interrupt_index) = (uint32_t)fnc;

--- a/cores/arduino/IRQManager.h
+++ b/cores/arduino/IRQManager.h
@@ -125,6 +125,11 @@ typedef struct timer {
     agt_extended_cfg_t *agt_ext_cfg;
 } TimerIrqCfg_t;
 
+typedef struct genericIrq {
+	IRQn_Type irq;
+	uint8_t ipl;
+	elc_event_t event;
+} GenericIrqCfg_t;
 
 
 #ifdef __cplusplus
@@ -199,7 +204,8 @@ class IRQManager {
        it returns true if the interrupt is correctly added */
     bool addDMA(dmac_extended_cfg_t &cfg, Irq_f fnc = nullptr);
 #endif
-
+    
+    bool addGenericInterrupt(GenericIrqCfg_t &cfg, Irq_f fnc = nullptr);
     bool addTimerOverflow(TimerIrqCfg_t &cfg, Irq_f fnc = nullptr);
     bool addTimerUnderflow(TimerIrqCfg_t &cfg, Irq_f fnc = nullptr);
     bool addTimerCompareCaptureA(TimerIrqCfg_t &cfg, Irq_f fnc = nullptr);


### PR DESCRIPTION
I'm proposing this as an alternative to #315 that keeps the dangerous code inside the IRQManager class.  This is a fix for #310

@facchinm would something like this work as an alternative?

Here's a test sketch.  I know we already have attachInterrupt for pin interrupts, but I already had this set up for testing.

```
#include "IRQManager.h"

volatile bool interruptFired = false;

GenericIrqCfg_t cfg;

void setup() {

  Serial.begin(115200);
  while (!Serial)
    ;
  Serial.println("\n\n *** " __FILE__ " ***\n\n");

  R_ICU->IRQCR[0] = 0xB0;  // Configure some peripheral for an interrupt

  // Create a generic interrupt configuration and attach
  cfg.irq = FSP_INVALID_VECTOR;
  cfg.ipl = 12;
  cfg.event = ELC_EVENT_ICU_IRQ0;  
  IRQManager::getInstance().addGenericInterrupt(cfg, Myirq0_callback);

  // Enable the interrupt at the peripheral. 
  R_PFS->PORT[1].PIN[5].PmnPFS = (1 << R_PFS_PORT_PIN_PmnPFS_PCR_Pos) | (1 << R_PFS_PORT_PIN_PmnPFS_ISEL_Pos);

}

void loop() {
  Serial.println("Loop Running");
  delay(500);

  if (interruptFired) {
    interruptFired = false;
    Serial.println("Interrupt Fired");
  }
}

void Myirq0_callback() {
  R_ICU->IELSR[cfg.irq] &= ~(R_ICU_IELSR_IR_Msk);
  interruptFired = true;
}
```