### PR TITLE
Fix buffer-overflow assigning global Wire instances.

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -30,8 +30,8 @@ extern "C" {
 
 #include "Wire.h"
 
-TwoWire *TwoWire::g_SCIWires[TWOWIRE_MAX_I2C_CHANNELS] = {nullptr};
-TwoWire *TwoWire::g_I2CWires[TWOWIRE_MAX_SCI_CHANNELS] = {nullptr};
+TwoWire *TwoWire::g_SCIWires[TWOWIRE_MAX_SCI_CHANNELS] = {nullptr};
+TwoWire *TwoWire::g_I2CWires[TWOWIRE_MAX_I2C_CHANNELS] = {nullptr};
 
 /* -------------------------------------------------------------------------- */
 void TwoWire::setBusStatus(WireStatus_t ws) {

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -152,8 +152,8 @@ class TwoWire : public arduino::HardwareI2C {
 
   private:
     
-    static TwoWire *g_SCIWires[TWOWIRE_MAX_I2C_CHANNELS];
-    static TwoWire *g_I2CWires[TWOWIRE_MAX_SCI_CHANNELS];
+    static TwoWire *g_SCIWires[TWOWIRE_MAX_SCI_CHANNELS];
+    static TwoWire *g_I2CWires[TWOWIRE_MAX_I2C_CHANNELS];
     
     static void WireSCIMasterCallback(i2c_master_callback_args_t *);
     static void WireMasterCallback(i2c_master_callback_args_t *);


### PR DESCRIPTION
Two pointer arrays declared, which contain pointers to the global SCI/I2C Wire instances: "g_SCIWires" and "g_I2CWires". Since there's a different number of SCI vs pure I2C "I2C" interfaces those buffers are of different size. Due to a typo the constant declaring the size of the pointe rarray for "g_SCIWires" ("TWOWIRE_MAX_SCI_CHANNELS") was used to define the size of "g_I2CWires" and vice versa. This had the result that on Portenta C33, íf you were calling "TwoWire::_begin()" for "Wire3" (which has channel "3") a buffer overflow occurs and random memory is overwritten.