### PR TITLE
libraries: Fix possible buffer/stack overflows in multiple libraries.

### DIFF
--- a/libraries/SE05X/src/lib/platform/arduino/sm_port.cpp
+++ b/libraries/SE05X/src/lib/platform/arduino/sm_port.cpp
@@ -23,7 +23,7 @@ void smlog_print(const char *format, ...) {
     char debug_buf[1024];   
     va_list argptr;
     va_start(argptr, format);
-    vsprintf(debug_buf, format, argptr);
+    vsnprintf(debug_buf, sizeof(debug_buf), format, argptr);
     va_end(argptr);
     Serial.print(debug_buf);
 }

--- a/libraries/SSLClient/src/ssl_debug.cpp
+++ b/libraries/SSLClient/src/ssl_debug.cpp
@@ -23,7 +23,7 @@ void ssl_debug_print(const char *format, ...) {
     char debug_buf[1024];   
     va_list argptr;
     va_start(argptr, format);
-    vsprintf(debug_buf, format, argptr);
+    vsnprintf(debug_buf, sizeof(debug_buf), format, argptr);
     va_end(argptr);
     Serial.print(debug_buf);
 }
@@ -32,7 +32,7 @@ void ssl_debug_println(const char *format, ...) {
     char debug_buf[1024];   
     va_list argptr;
     va_start(argptr, format);
-    vsprintf(debug_buf, format, argptr);
+    vsnprintf(debug_buf, sizeof(debug_buf), format, argptr);
     va_end(argptr);
     Serial.println(debug_buf);
 }

--- a/libraries/WiFiS3/src/Modem.cpp
+++ b/libraries/WiFiS3/src/Modem.cpp
@@ -88,10 +88,9 @@ bool ModemClass::passthrough(const uint8_t *data, size_t size) {
 /* -------------------------------------------------------------------------- */
 void ModemClass::write_nowait(const string &cmd, string &str, char * fmt, ...) {
 /* -------------------------------------------------------------------------- */   
-   memset(tx_buff,0x00,MAX_BUFF_SIZE);
    va_list va;
    va_start (va, fmt);
-   vsprintf ((char *)tx_buff, fmt, va);
+   vsnprintf((char *)tx_buff, MAX_BUFF_SIZE, fmt, va);
    va_end (va);
    
    if(_serial_debug && _debug_level >= 2) { 
@@ -109,10 +108,9 @@ void ModemClass::write_nowait(const string &cmd, string &str, char * fmt, ...) {
 bool ModemClass::write(const string &prompt, string &data_res, char * fmt, ...){
 /* -------------------------------------------------------------------------- */  
    data_res.clear();
-   memset(tx_buff,0x00,MAX_BUFF_SIZE);
    va_list va;
    va_start (va, fmt);
-   vsprintf ((char *)tx_buff, fmt, va);
+   vsnprintf((char *)tx_buff, MAX_BUFF_SIZE, fmt, va);
    va_end (va);
   
    if(_serial_debug) {

--- a/libraries/lwIpWrapper/src/CNetIf.cpp
+++ b/libraries/lwIpWrapper/src/CNetIf.cpp
@@ -1567,10 +1567,9 @@ char b_dbg[512];
 extern "C" void printDbg(const char* fmt, ...)
 {
 
-    memset(b_dbg, 0x00, 256);
     va_list va;
     va_start(va, fmt);
-    vsprintf(b_dbg, fmt, va);
+    vsnprintf(b_dbg, sizeof(b_dbg), fmt, va);
     va_end(va);
 
     Serial.println(b_dbg);


### PR DESCRIPTION
`vsprintf` should be avoided as it could easily overflow the buffer if the formatted string exceeds the max buffer size. `vsnprintf`, on the other hand, checks a buffer size argument. Note that they both null-terminate the string, so calling `memset` beforehand is not necessary.