### PR TITLE
bounds check for last_interrupt_index

### DIFF
--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -609,7 +609,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         mcfg->ipl = I2C_MASTER_PRIORITY;
         
         if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + WIRE_MASTER_INTERRUPT_COUNT >= PROG_IRQ_NUM){
+            if (last_interrupt_index + WIRE_MASTER_INTERRUPT_COUNT > PROG_IRQ_NUM){
                 rv = false;
                 goto end_config;
             } 
@@ -658,7 +658,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
         mcfg->ipl = I2C_MASTER_PRIORITY;
         if (mcfg->txi_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + WIRE_SCI_MASTER_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+            if (last_interrupt_index + WIRE_SCI_MASTER_INTERRUPT_COUNT > PROG_IRQ_NUM) {
                 rv = false;
                 goto end_config;
             }
@@ -707,7 +707,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         scfg->eri_ipl = I2C_SLAVE_PRIORITY;
 
         if (scfg->txi_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + WIRE_SLAVE_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+            if (last_interrupt_index + WIRE_SLAVE_INTERRUPT_COUNT > PROG_IRQ_NUM) {
                 rv = false;
                 goto end_config;
             }
@@ -773,7 +773,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         uint8_t const hw_channel = reinterpret_cast<SpiMasterIrqReq_t *>(cfg)->hw_channel;
 
         if (p_cfg->txi_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + SPI_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+            if (last_interrupt_index + SPI_INTERRUPT_COUNT > PROG_IRQ_NUM) {
                 rv = false;
                 goto end_config;
             } 
@@ -825,7 +825,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         uint8_t const hw_channel = reinterpret_cast<SciSpiMasterIrqReq_t *>(cfg)->hw_channel;
 
         if (p_cfg->txi_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + SPI_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+            if (last_interrupt_index + SPI_INTERRUPT_COUNT > PROG_IRQ_NUM) {
                 rv = false;
                 goto end_config;
             } 
@@ -878,7 +878,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         p_cfg->ipl = CAN_PRIORITY; /* All interrupts share the same priority. */
 
         if (p_cfg->error_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + CAN_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+            if (last_interrupt_index + CAN_INTERRUPT_COUNT > PROG_IRQ_NUM) {
                 rv = false;
                 goto end_config;
             } 
@@ -936,7 +936,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         p_cfg->ipl = CAN_PRIORITY; /* All interrupts share the same priority. */
 
         if (p_cfg->error_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + CANFD_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+            if (last_interrupt_index + CANFD_INTERRUPT_COUNT > PROG_IRQ_NUM) {
                 rv = false;
                 goto end_config;
             }   
@@ -975,7 +975,7 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         sdmmc_cfg_t *sd_cfg = (sdmmc_cfg_t *)cfg;
         /* SDCARD_ACCESS */
         if(sd_cfg->access_irq == FSP_INVALID_VECTOR) {
-            if (last_interrupt_index + SD_INTERRUPT_COUNT >= PROG_IRQ_NUM){
+            if (last_interrupt_index + SD_INTERRUPT_COUNT > PROG_IRQ_NUM){
                 rv = false;
                 goto end_config;
             }   

--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -510,7 +510,12 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
        ********************************************************************** */
     else if(p == IRQ_SCI_UART && cfg != NULL) {
         uart_cfg_t *p_cfg = (uart_cfg_t *)cfg;
+        
         if (p_cfg->txi_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + UART_INTERRUPT_COUNT > PROG_IRQ_NUM){
+                rv = false;
+                goto end_config;
+            }
             /* TX interrupt */
             p_cfg->txi_ipl = UART_SCI_PRIORITY;
             p_cfg->txi_irq = (IRQn_Type)last_interrupt_index;
@@ -596,13 +601,18 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
 
 #if WIRE_HOWMANY > 0
     /* I2C true NOT SCI */
-    else if(p == IRQ_I2C_MASTER && cfg != NULL) {
+    else if(p == IRQ_I2C_MASTER && cfg != NULL) {       
+
         I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
         i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
         i2c_slave_cfg_t *scfg = (i2c_slave_cfg_t *)p_cfg->scfg;
         mcfg->ipl = I2C_MASTER_PRIORITY;
         
         if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + WIRE_MASTER_INTERRUPT_COUNT >= PROG_IRQ_NUM){
+                rv = false;
+                goto end_config;
+            } 
             /* TX interrupt */
             mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
             scfg->txi_irq = (IRQn_Type)last_interrupt_index;
@@ -643,11 +653,15 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         R_BSP_IrqEnable (mcfg->eri_irq);
     }
     /* I2C SCI MASTER (only) */
-    else if(p == IRQ_SCI_I2C_MASTER && cfg != NULL) {
+    else if(p == IRQ_SCI_I2C_MASTER && cfg != NULL) {      
         I2CIrqReq_t *p_cfg = (I2CIrqReq_t *)cfg;
         i2c_master_cfg_t *mcfg = (i2c_master_cfg_t *)p_cfg->mcfg;
         mcfg->ipl = I2C_MASTER_PRIORITY;
-        if (mcfg->txi_irq  == FSP_INVALID_VECTOR) {
+        if (mcfg->txi_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + WIRE_SCI_MASTER_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+                rv = false;
+                goto end_config;
+            }
             /* TX interrupt */
             mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)sci_i2c_txi_isr;
@@ -691,8 +705,12 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         i2c_slave_cfg_t *scfg = (i2c_slave_cfg_t *)p_cfg->scfg;
         scfg->ipl = I2C_SLAVE_PRIORITY;
         scfg->eri_ipl = I2C_SLAVE_PRIORITY;
-        
-        if (scfg->txi_irq  == FSP_INVALID_VECTOR) {
+
+        if (scfg->txi_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + WIRE_SLAVE_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+                rv = false;
+                goto end_config;
+            }
             /* TX interrupt */
             mcfg->txi_irq = (IRQn_Type)last_interrupt_index;
             scfg->txi_irq = (IRQn_Type)last_interrupt_index;
@@ -749,12 +767,16 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     /* **********************************************************************
                                       SPI MASTER
        ********************************************************************** */
-    else if(p == IRQ_SPI_MASTER && cfg != NULL) {
+    else if(p == IRQ_SPI_MASTER && cfg != NULL) {      
         spi_instance_ctrl_t * p_ctrl = reinterpret_cast<SpiMasterIrqReq_t *>(cfg)->ctrl;
         spi_cfg_t  * p_cfg  = reinterpret_cast<SpiMasterIrqReq_t *>(cfg)->cfg;
         uint8_t const hw_channel = reinterpret_cast<SpiMasterIrqReq_t *>(cfg)->hw_channel;
 
         if (p_cfg->txi_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + SPI_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+                rv = false;
+                goto end_config;
+            } 
             /* TX interrupt */
             p_cfg->txi_irq = (IRQn_Type)last_interrupt_index;
             p_cfg->txi_ipl = SPI_MASTER_PRIORITY;
@@ -797,12 +819,16 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     /* **********************************************************************
                                     SCI SPI MASTER
        ********************************************************************** */
-    else if(p == IRQ_SCI_SPI_MASTER && cfg != NULL) {
+    else if(p == IRQ_SCI_SPI_MASTER && cfg != NULL) {  
         sci_spi_instance_ctrl_t * p_ctrl = reinterpret_cast<SciSpiMasterIrqReq_t *>(cfg)->ctrl;
         spi_cfg_t  * p_cfg  = reinterpret_cast<SciSpiMasterIrqReq_t *>(cfg)->cfg;
         uint8_t const hw_channel = reinterpret_cast<SciSpiMasterIrqReq_t *>(cfg)->hw_channel;
 
         if (p_cfg->txi_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + SPI_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+                rv = false;
+                goto end_config;
+            } 
             /* TX interrupt */
             p_cfg->txi_irq = (IRQn_Type)last_interrupt_index;
             p_cfg->txi_ipl = SPI_MASTER_PRIORITY;
@@ -846,12 +872,16 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     /* **********************************************************************
                                       CAN
        ********************************************************************** */
-    else if(p == IRQ_CAN && cfg != NULL) {
+    else if(p == IRQ_CAN && cfg != NULL) {  
         can_instance_ctrl_t * p_ctrl = reinterpret_cast<CanIrqReq_t *>(cfg)->ctrl;
         can_cfg_t * p_cfg  = reinterpret_cast<CanIrqReq_t *>(cfg)->cfg;
         p_cfg->ipl = CAN_PRIORITY; /* All interrupts share the same priority. */
 
         if (p_cfg->error_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + CAN_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+                rv = false;
+                goto end_config;
+            } 
             /* Error interrupt */
             p_cfg->error_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)can_error_isr;
@@ -906,6 +936,10 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         p_cfg->ipl = CAN_PRIORITY; /* All interrupts share the same priority. */
 
         if (p_cfg->error_irq == FSP_INVALID_VECTOR) {
+            if (last_interrupt_index + CANFD_INTERRUPT_COUNT >= PROG_IRQ_NUM) {
+                rv = false;
+                goto end_config;
+            }   
             /* Error interrupt */
             p_cfg->error_irq = (IRQn_Type)last_interrupt_index;
             *(irq_ptr + last_interrupt_index) = (uint32_t)canfd_error_isr;
@@ -941,7 +975,10 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
         sdmmc_cfg_t *sd_cfg = (sdmmc_cfg_t *)cfg;
         /* SDCARD_ACCESS */
         if(sd_cfg->access_irq == FSP_INVALID_VECTOR) {
-
+            if (last_interrupt_index + SD_INTERRUPT_COUNT >= PROG_IRQ_NUM){
+                rv = false;
+                goto end_config;
+            }   
             sd_cfg->access_irq = (IRQn_Type)last_interrupt_index;
             sd_cfg->access_ipl = SDCARD_ACCESS_PRIORITY;
             *(irq_ptr + last_interrupt_index) = (uint32_t)sdhimmc_accs_isr;

--- a/cores/arduino/IRQManager.cpp
+++ b/cores/arduino/IRQManager.cpp
@@ -67,8 +67,10 @@ bool IRQManager::addADCScanEnd(ADC_Container *adc, Irq_f fnc /*= nullptr*/) {
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
-    
-    if (adc->cfg.scan_end_irq == FSP_INVALID_VECTOR) {
+    if (last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+    }
+    else if (adc->cfg.scan_end_irq == FSP_INVALID_VECTOR) {
         if(set_adc_end_link_event(last_interrupt_index, adc->cfg.unit)) {
             adc->cfg.scan_end_ipl = TIMER_PRIORITY;
             adc->cfg.scan_end_irq = (IRQn_Type)last_interrupt_index;
@@ -101,8 +103,10 @@ bool IRQManager::addADCScanEndB(ADC_Container *adc, Irq_f fnc /*= nullptr*/) {
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
-
-    if (adc->cfg.scan_end_b_irq == FSP_INVALID_VECTOR) {
+    if (last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+    }
+    else if (adc->cfg.scan_end_b_irq == FSP_INVALID_VECTOR) {
         if(set_adc_end_b_link_event(last_interrupt_index, adc->cfg.unit)) {
             adc->cfg.scan_end_b_ipl = TIMER_PRIORITY;
             adc->cfg.scan_end_b_irq = (IRQn_Type)last_interrupt_index;
@@ -125,8 +129,10 @@ bool IRQManager::addADCWinCmpA(ADC_Container *adc, Irq_f fnc /*= nullptr*/) {
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
-    
-    if( ((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_a_irq == FSP_INVALID_VECTOR) {
+    if (last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+    }
+    else if( ((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_a_irq == FSP_INVALID_VECTOR) {
         if(set_adc_win_a_link_event(last_interrupt_index, adc->cfg.unit)) {
             ((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_a_ipl = TIMER_PRIORITY;
             ((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_a_irq = (IRQn_Type)last_interrupt_index;
@@ -150,8 +156,10 @@ bool IRQManager::addADCWinCmpB(ADC_Container *adc, Irq_f fnc /*= nullptr*/) {
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
-    
-    if (((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_b_irq == FSP_INVALID_VECTOR) {
+    if (last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+    }
+    else if (((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_b_irq == FSP_INVALID_VECTOR) {
         if(set_adc_win_b_link_event(last_interrupt_index, adc->cfg.unit)) {
             ((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_b_ipl = TIMER_PRIORITY;
             ((adc_extended_cfg_t *)(adc->cfg.p_extend))->window_b_irq = (IRQn_Type)last_interrupt_index;
@@ -177,8 +185,10 @@ bool IRQManager::addTimerOverflow(TimerIrqCfg_t &cfg, Irq_f fnc /* = nullptr */)
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
-
-    if (cfg.base_cfg->cycle_end_irq == FSP_INVALID_VECTOR) {
+    if (last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+    }
+    else if (cfg.base_cfg->cycle_end_irq == FSP_INVALID_VECTOR) {
         if(cfg.gpt_ext_cfg != nullptr) {
             if(set_gpt_over_link_event(last_interrupt_index, cfg.base_cfg->channel)) {
                 cfg.base_cfg->cycle_end_ipl = TIMER_PRIORITY;
@@ -224,7 +234,7 @@ bool IRQManager::addTimerUnderflow(TimerIrqCfg_t &cfg, Irq_f fnc /*= nullptr*/) 
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
     
-    if(cfg.agt_ext_cfg != nullptr) {
+    if((cfg.agt_ext_cfg != nullptr) || (last_interrupt_index >= PROG_IRQ_NUM)) {
         /* not supported for AGT  */
         rv = false;
     }
@@ -258,7 +268,7 @@ bool IRQManager::addTimerCompareCaptureA(TimerIrqCfg_t &cfg, Irq_f fnc /*= nullp
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
     
-    if(cfg.agt_ext_cfg != nullptr) {
+    if((cfg.agt_ext_cfg != nullptr) || (last_interrupt_index >= PROG_IRQ_NUM)) {
         /* not supported for AGT  */
         rv = false;
     }
@@ -292,7 +302,7 @@ bool IRQManager::addTimerCompareCaptureB(TimerIrqCfg_t &cfg, Irq_f fnc /*= nullp
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
     
-    if(cfg.agt_ext_cfg != nullptr) {
+    if((cfg.agt_ext_cfg != nullptr) || (last_interrupt_index >= PROG_IRQ_NUM)) {
         /* not supported for AGT  */
         rv = false;
     }
@@ -326,8 +336,10 @@ bool IRQManager::addDMA(dmac_extended_cfg_t &cfg, Irq_f fnc /* = nullptr */) {
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
-    
-    if (cfg.irq == FSP_INVALID_VECTOR) {
+    if (last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+    }
+    else if (cfg.irq == FSP_INVALID_VECTOR) {
         /* to check correctness of the channel */
         if(set_dma_link_event(last_interrupt_index, cfg.channel)) {
             cfg.ipl = DMA_PRIORITY;
@@ -356,6 +368,11 @@ bool IRQManager::addPeripheral(Peripheral_t p, void *cfg) {
     /* set the displacement to the "programmable" part of the table */
     irq_ptr += FIXED_IRQ_NUM;
     bool rv = true;
+
+    if(last_interrupt_index >= PROG_IRQ_NUM){
+        rv = false;
+        goto end_config;
+    }
 
     __disable_irq();
     /* **********************************************************************

--- a/cores/arduino/IRQManager.h
+++ b/cores/arduino/IRQManager.h
@@ -12,6 +12,7 @@
 
 #if SERIAL_HOWMANY > 0
 #include "r_uart_api.h"
+#define UART_INTERRUPT_COUNT 4
 #endif
 
 #if EXT_INTERRUPTS_HOWMANY > 0
@@ -78,6 +79,9 @@ typedef struct i2c_irq_req {
     i2c_master_cfg_t *mcfg;
     i2c_slave_cfg_t  *scfg;
 } I2CIrqReq_t;
+#define WIRE_MASTER_INTERRUPT_COUNT 4
+#define WIRE_SLAVE_INTERRUPT_COUNT 4
+#define WIRE_SCI_MASTER_INTERRUPT_COUNT 3
 #endif
 
 #if SPI_HOWMANY > 0
@@ -95,6 +99,7 @@ typedef struct sci_spi_master_irq {
     spi_cfg_t * cfg;
     uint8_t hw_channel;
 } SciSpiMasterIrqReq_t;
+#define SPI_INTERRUPT_COUNT 4
 #endif
 
 #if CAN_HOWMANY > 0
@@ -103,6 +108,7 @@ typedef struct can_irq {
   can_instance_ctrl_t * ctrl;
   can_cfg_t * cfg;
 } CanIrqReq_t;
+#define CAN_INTERRUPT_COUNT 3
 #endif /* CAN_HOWMANY > 0 */
 
 #if CANFD_HOWMANY > 0
@@ -111,7 +117,10 @@ typedef struct canfd_irq {
   canfd_instance_ctrl_t * ctrl;
   can_cfg_t * cfg;
 } CanFdIrqReq_t;
+#define CANFD_INTERRUPT_COUNT 3
 #endif /* CANFD_HOWMANY > 0 */
+
+#define SD_INTERRUPT_COUNT 2
 
 typedef struct usb {
     uint32_t num_of_irqs_required;


### PR DESCRIPTION
Based on discussion from #316 I'm proposing this pull to add bounds checking for the last_interrupt_index to all functions in the IRQManager class that add interrupts.  