### PR TITLE
 Fix Inconsistent Sleep Current by relocating the Ethernet Clock AGT Timer 

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -1,5 +1,5 @@
 #include <EthernetC33.h>
-
+#include <EthernetClock.h>
 /*
  * The old implementation of the begin set a default mac address:
  * this does not make any sense.
@@ -12,9 +12,14 @@
 /* -------------------------------------------------------------------------- */
 int CEthernet::begin(unsigned long timeout, unsigned long responseTimeout) {
 /* -------------------------------------------------------------------------- */  
+    
+  ethernetTimer = new EthernetClock();
+  ethernetTimer->start();
+  delay(2);
   (void)responseTimeout;
 
   int rv = 0;
+
 
   ni = CLwipIf::getInstance().get(NI_ETHERNET);
   if(ni != nullptr) {
@@ -55,6 +60,10 @@ int CEthernet::begin(IPAddress local_ip, IPAddress dns_server, IPAddress gateway
 /* -------------------------------------------------------------------------- */
 int CEthernet::begin(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet) {
 /* -------------------------------------------------------------------------- */  
+  
+  ethernetTimer = new EthernetClock();
+  ethernetTimer->start();
+  delay(2);
   
   if (ni != nullptr) {
     ni->config(local_ip, gateway, subnet);
@@ -136,6 +145,9 @@ EthernetHardwareStatus CEthernet::hardwareStatus() {
 /* -------------------------------------------------------------------------- */
 int CEthernet::disconnect() {
 /* -------------------------------------------------------------------------- */
+  ethernetTimer->stop();
+  delete(ethernetTimer);
+  ethernetTimer = NULL;
   return 1;
 }
 

--- a/libraries/Ethernet/src/EthernetC33.h
+++ b/libraries/Ethernet/src/EthernetC33.h
@@ -13,6 +13,7 @@
 
 #include "EthernetClient.h"
 #include "EthernetServer.h"
+#include "EthernetClock.h"
 
 #include "CNetIf.h"
 #include "lwipMem.h"
@@ -68,8 +69,11 @@ class CEthernet {
     IPAddress gatewayIP();
     IPAddress dnsServerIP();
 
+
     friend class EthernetClient;
     friend class EthernetServer;
+  private:
+    EthernetClock * ethernetTimer;
 };
 
 extern CEthernet Ethernet;

--- a/libraries/Ethernet/src/EthernetClock.cpp
+++ b/libraries/Ethernet/src/EthernetClock.cpp
@@ -1,0 +1,62 @@
+#include "EthernetClock.h"
+
+
+
+EthernetClock::EthernetClock() {
+  pinPeripheral(ETHERNET_CLK_PIN, (uint32_t) (IOPORT_CFG_PERIPHERAL_PIN | IOPORT_PERIPHERAL_AGT));
+
+  this->TIMER_ETHERNET_extend.count_source = AGT_CLOCK_PCLKB;
+  this->TIMER_ETHERNET_extend.agto = AGT_PIN_CFG_START_LEVEL_LOW;
+  this->TIMER_ETHERNET_extend.agtoab_settings_b.agtoa = AGT_PIN_CFG_DISABLED;
+  this->TIMER_ETHERNET_extend.agtoab_settings_b.agtob = AGT_PIN_CFG_DISABLED;
+  this->TIMER_ETHERNET_extend.measurement_mode = AGT_MEASURE_DISABLED;
+  this->TIMER_ETHERNET_extend.agtio_filter = AGT_AGTIO_FILTER_NONE;
+  this->TIMER_ETHERNET_extend.enable_pin = AGT_ENABLE_PIN_NOT_USED;
+  this->TIMER_ETHERNET_extend.trigger_edge = AGT_TRIGGER_EDGE_RISING;
+
+  this->TIMER_ETHERNET_cfg.mode = TIMER_MODE_PERIODIC;
+  this->TIMER_ETHERNET_cfg.period_counts = (uint32_t) 0x1;
+  this->TIMER_ETHERNET_cfg.duty_cycle_counts = 0x00;
+  this->TIMER_ETHERNET_cfg.source_div = (timer_source_div_t) 0;
+  this->TIMER_ETHERNET_cfg.channel = AGT_TIMER_CHANNEL;
+  this->TIMER_ETHERNET_cfg.p_callback = NULL;
+  this->TIMER_ETHERNET_cfg.p_context  = NULL;
+  this->TIMER_ETHERNET_cfg.p_extend = &TIMER_ETHERNET_extend;
+  this->TIMER_ETHERNET_cfg.cycle_end_ipl = (BSP_IRQ_DISABLED);
+  this->TIMER_ETHERNET_cfg.cycle_end_irq = FSP_INVALID_VECTOR;
+}
+
+fsp_err_t EthernetClock::start() {
+  fsp_err_t err = R_AGT_Open(&this->TIMER_ETHERNET_ctrl,&this->TIMER_ETHERNET_cfg);
+  if (err != FSP_SUCCESS) {
+    return err;
+  }
+  err = R_AGT_Enable(&this->TIMER_ETHERNET_ctrl);
+  if (err != FSP_SUCCESS) {
+    return err;
+  }
+  err = R_AGT_Start(&this->TIMER_ETHERNET_ctrl);
+  if (err != FSP_SUCCESS) {
+    return err;
+  }
+
+  FspTimer::set_timer_is_used(AGT_TIMER, AGT_TIMER_CHANNEL);
+  return err;
+}
+
+fsp_err_t EthernetClock::stop() {
+  fsp_err_t err = R_AGT_Stop(&this->TIMER_ETHERNET_ctrl);
+  if (err != FSP_SUCCESS) {
+    return err;
+  } else {
+    err = R_AGT_Close(&this->TIMER_ETHERNET_ctrl);
+    if (err != FSP_SUCCESS) {
+      return err;
+    } else {
+      err = R_AGT_Disable(&this->TIMER_ETHERNET_ctrl);
+      if (err != FSP_SUCCESS) {
+        return err;
+      }
+    }
+  }
+}

--- a/libraries/Ethernet/src/EthernetClock.cpp
+++ b/libraries/Ethernet/src/EthernetClock.cpp
@@ -1,6 +1,7 @@
 #include "EthernetClock.h"
+#include "pins_arduino.h"
 
-
+#if defined(ETHERNET_CLK_PIN)
 
 EthernetClock::EthernetClock() {
   pinPeripheral(ETHERNET_CLK_PIN, (uint32_t) (IOPORT_CFG_PERIPHERAL_PIN | IOPORT_PERIPHERAL_AGT));
@@ -18,7 +19,7 @@ EthernetClock::EthernetClock() {
   this->TIMER_ETHERNET_cfg.period_counts = (uint32_t) 0x1;
   this->TIMER_ETHERNET_cfg.duty_cycle_counts = 0x00;
   this->TIMER_ETHERNET_cfg.source_div = (timer_source_div_t) 0;
-  this->TIMER_ETHERNET_cfg.channel = AGT_TIMER_CHANNEL;
+  this->TIMER_ETHERNET_cfg.channel = ETHERNET_AGT_TIMER_CHANNEL;
   this->TIMER_ETHERNET_cfg.p_callback = NULL;
   this->TIMER_ETHERNET_cfg.p_context  = NULL;
   this->TIMER_ETHERNET_cfg.p_extend = &TIMER_ETHERNET_extend;
@@ -40,7 +41,7 @@ fsp_err_t EthernetClock::start() {
     return err;
   }
 
-  FspTimer::set_timer_is_used(AGT_TIMER, AGT_TIMER_CHANNEL);
+  FspTimer::set_timer_is_used(AGT_TIMER, ETHERNET_AGT_TIMER_CHANNEL);
   return err;
 }
 
@@ -60,3 +61,18 @@ fsp_err_t EthernetClock::stop() {
     }
   }
 }
+
+#else
+
+EthernetClock::EthernetClock() {
+}
+
+fsp_err_t EthernetClock::start() {
+  return FSP_SUCCESS;
+}
+
+fsp_err_t EthernetClock::stop() {
+  return FSP_SUCCESS;
+}
+
+#endif

--- a/libraries/Ethernet/src/EthernetClock.h
+++ b/libraries/Ethernet/src/EthernetClock.h
@@ -1,0 +1,23 @@
+
+#ifndef ETHERNET_CLOCK_H
+#define ETHERNET_CLOCK_H
+
+#include "FspTimer.h"
+
+#define AGT_TIMER_CHANNEL 3
+#define ETHERNET_CLK_PIN  BSP_IO_PORT_06_PIN_00
+
+
+class EthernetClock {
+    public:
+        EthernetClock();
+        fsp_err_t start();
+        fsp_err_t stop();
+
+    private:
+        agt_instance_ctrl_t TIMER_ETHERNET_ctrl;
+        agt_extended_cfg_t TIMER_ETHERNET_extend;
+        timer_cfg_t TIMER_ETHERNET_cfg;
+};
+
+#endif

--- a/libraries/Ethernet/src/EthernetClock.h
+++ b/libraries/Ethernet/src/EthernetClock.h
@@ -4,10 +4,6 @@
 
 #include "FspTimer.h"
 
-#define AGT_TIMER_CHANNEL 3
-#define ETHERNET_CLK_PIN  BSP_IO_PORT_06_PIN_00
-
-
 class EthernetClock {
     public:
         EthernetClock();

--- a/variants/PORTENTA_C33/pins_arduino.h
+++ b/variants/PORTENTA_C33/pins_arduino.h
@@ -209,3 +209,6 @@ static const uint8_t SS  =  PIN_SPI_CS;
 #define RTC_CLOCK_SOURCE    RTC_CLOCK_SOURCE_SUBCLK
 
 #define AR_INTERNAL_VOLTAGE     1.18f
+
+#define ETHERNET_AGT_TIMER_CHANNEL      3
+#define ETHERNET_CLK_PIN                BSP_IO_PORT_06_PIN_00

--- a/variants/PORTENTA_C33/variant.cpp
+++ b/variants/PORTENTA_C33/variant.cpp
@@ -216,58 +216,8 @@ int32_t getPinIndex(bsp_io_port_pin_t p) {
   return rv;
 }
 
-#include "FspTimer.h"
-
-#define AGT_TIMER_CHANNEL 3
-#define ETHERNET_CLK_PIN  BSP_IO_PORT_06_PIN_00
-
-agt_instance_ctrl_t TIMER_ETHERNET_ctrl;
-agt_extended_cfg_t TIMER_ETHERNET_extend;
-timer_cfg_t TIMER_ETHERNET_cfg;
-
-
-fsp_err_t startETHClock() {
-  pinPeripheral(ETHERNET_CLK_PIN, (uint32_t) (IOPORT_CFG_PERIPHERAL_PIN | IOPORT_PERIPHERAL_AGT));
-  
-  TIMER_ETHERNET_extend.count_source = AGT_CLOCK_PCLKB;
-  TIMER_ETHERNET_extend.agto = AGT_PIN_CFG_START_LEVEL_LOW;
-  TIMER_ETHERNET_extend.agtoab_settings_b.agtoa = AGT_PIN_CFG_DISABLED;
-  TIMER_ETHERNET_extend.agtoab_settings_b.agtob = AGT_PIN_CFG_DISABLED;
-  TIMER_ETHERNET_extend.measurement_mode = AGT_MEASURE_DISABLED;
-  TIMER_ETHERNET_extend.agtio_filter = AGT_AGTIO_FILTER_NONE;
-  TIMER_ETHERNET_extend.enable_pin = AGT_ENABLE_PIN_NOT_USED;
-  TIMER_ETHERNET_extend.trigger_edge = AGT_TRIGGER_EDGE_RISING;
-  
-  TIMER_ETHERNET_cfg.mode = TIMER_MODE_PERIODIC;
-  TIMER_ETHERNET_cfg.period_counts = (uint32_t) 0x1;
-  TIMER_ETHERNET_cfg.duty_cycle_counts = 0x00;
-  TIMER_ETHERNET_cfg.source_div = (timer_source_div_t) 0;
-  TIMER_ETHERNET_cfg.channel = AGT_TIMER_CHANNEL; 
-  TIMER_ETHERNET_cfg.p_callback = NULL;
-  TIMER_ETHERNET_cfg.p_context  = NULL;
-  TIMER_ETHERNET_cfg.p_extend = &TIMER_ETHERNET_extend;
-  TIMER_ETHERNET_cfg.cycle_end_ipl = (BSP_IRQ_DISABLED);
-  TIMER_ETHERNET_cfg.cycle_end_irq = FSP_INVALID_VECTOR;
-  
-  fsp_err_t err = R_AGT_Open(&TIMER_ETHERNET_ctrl,&TIMER_ETHERNET_cfg);
-  if (err != FSP_SUCCESS) {
-    return err;
-  }
-  err = R_AGT_Enable(&TIMER_ETHERNET_ctrl);
-  if (err != FSP_SUCCESS) {
-    return err;
-  }
-  err = R_AGT_Start(&TIMER_ETHERNET_ctrl);
-  if (err != FSP_SUCCESS) {
-    return err;
-  }
-
-  FspTimer::set_timer_is_used(AGT_TIMER, AGT_TIMER_CHANNEL);
-  return err;
-}
-
 void initVariant() {
-  startETHClock();
+
   // bootloader configures LED_BUILTIN as PWM output, deconfigure it to avoid spurious signals
   pinMode(LED_BUILTIN, INPUT);
 }


### PR DESCRIPTION
**Description:**
This pull request addresses an issue with inconsistent sleep current consumption on the board. Previously, the board would sometimes draw around 100µA and other times around 2mA. After thorough investigation, it was determined that the issue was due to the lowest power supply state (LPM_POWER_SUPPLY_DEEPCUT3) of the Renesas RA6M5 chip turning off the AGT (Asynchronous General Purpose Timer), which conflicted with the AGT timer used for the Ethernet clock defined in variant.cpp.

**Changes:**
- Removed the AGT timer definition for the Ethernet clock in variant.cpp.
- Wrapped the AGT timer functionality in the EthernetClock class
- Added timer instantiation in the begin method of the Ethernet class.
- Added timer deletion in the disconnect method of the Ethernet class.

**Testing:**
- Verified that the board enters a consistent low-power state with current consumption around 60µA.
- Ensured that Ethernet functionality is not impacted by the changes.

**Additional Notes:**
- This fix improves power efficiency and stability in low-power modes.
- Please review the changes to ensure they align with the overall project architecture and coding standards.