### PR TITLE
Add RTC alarm setter without callback

### DIFF
--- a/libraries/RTC/src/RTC.cpp
+++ b/libraries/RTC/src/RTC.cpp
@@ -653,7 +653,11 @@ bool RTClock::setAlarmCallback(rtc_cbk_t fnc, RTCTime &t, AlarmMatch &m) {
     
     if(is_initialized) {
         onRtcInterrupt();
-        setRtcAlarmClbk(fnc);
+
+        if(fnc != nullptr) {
+            setRtcAlarmClbk(fnc);
+        }
+
         rtc_alarm_time_t at;
         at.min_match = false;               
         at.sec_match = false;                
@@ -682,6 +686,10 @@ bool RTClock::setAlarmCallback(rtc_cbk_t fnc, RTCTime &t, AlarmMatch &m) {
         }
     }
     return false;
+}
+
+bool RTClock::setAlarm(RTCTime &t, AlarmMatch &m) {
+    return this->setAlarmCallback(nullptr, t, m);
 }
 
 bool RTClock::isRunning() {

--- a/libraries/RTC/src/RTC.h
+++ b/libraries/RTC/src/RTC.h
@@ -181,6 +181,8 @@ class RTClock {
 
     bool setPeriodicCallback(rtc_cbk_t fnc, Period p);
     bool setAlarmCallback(rtc_cbk_t fnc, RTCTime &t, AlarmMatch &m);
+    bool setAlarm(RTCTime &t, AlarmMatch &m);
+    
     bool isRunning();
     bool setTime(RTCTime &t); 
     bool setTimeIfNotRunning(RTCTime &t);


### PR DESCRIPTION
This PR adds a new setter that doesn't require to pass an alarm callback. This is useful in Low Power scenarios in which the board resets after being woken up from the RTC. Therefore the callback would never be called anyway.