### PR TITLE
Fix for Serial flush() returning before transmission has completed

### DIFF
--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -58,12 +58,16 @@ void UART::WrapperCallback(uart_callback_args_t *p_args) {
       {
           break;
       }
-      case UART_EVENT_TX_COMPLETE:
-      case UART_EVENT_TX_DATA_EMPTY:
+      case UART_EVENT_TX_COMPLETE: // This is call when the transmission is complete
+      {
+        uart_ptr->tx_complete = true;
+        break;
+      }
+      case UART_EVENT_TX_DATA_EMPTY: // This is called when the buffer is empty
       {
         //uint8_t to_enqueue = uart_ptr->txBuffer.available() < uart_ptr->uart_ctrl.fifo_depth ? uart_ptr->txBuffer.available() : uart_ptr->uart_ctrl.fifo_depth;
         //while (to_enqueue) {
-        uart_ptr->tx_done = true;
+        uart_ptr->tx_empty = true;
         break;
       }
       case UART_EVENT_RX_CHAR:
@@ -109,9 +113,10 @@ bool UART::setUpUartIrqs(uart_cfg_t &cfg) {
 size_t UART::write(uint8_t c) {
 /* -------------------------------------------------------------------------- */  
   if(init_ok) {
-    tx_done = false;
+    tx_empty = false;
+    tx_complete = false;
     R_SCI_UART_Write(&uart_ctrl, &c, 1);
-    while (!tx_done) {}
+    while (!tx_empty) {}
     return 1;
   }
   else {
@@ -121,9 +126,10 @@ size_t UART::write(uint8_t c) {
 
 size_t  UART::write(uint8_t* c, size_t len) {
   if(init_ok) {
-    tx_done = false;
+    tx_empty = false;
+    tx_complete = false;
     R_SCI_UART_Write(&uart_ctrl, c, len);
-    while (!tx_done) {}
+    while (!tx_empty) {}
     return len;
   }
   else {
@@ -322,7 +328,7 @@ int UART::read() {
 /* -------------------------------------------------------------------------- */
 void UART::flush() {
 /* -------------------------------------------------------------------------- */  
-  while(txBuffer.available());
+  while(!tx_complete);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -78,7 +78,8 @@ class UART : public arduino::HardwareSerial {
     arduino::SafeRingBufferN<SERIAL_BUFFER_SIZE> rxBuffer;
     arduino::SafeRingBufferN<SERIAL_BUFFER_SIZE> txBuffer;
 
-    volatile bool tx_done;
+    volatile bool tx_empty;
+    volatile bool tx_complete;
 
     sci_uart_instance_ctrl_t  uart_ctrl;
     uart_cfg_t                uart_cfg;


### PR DESCRIPTION
Problem: flush() would return when the transmission buffer was empty, but the txBuffer was not being used so flush() would return straight away. write() would wait until it had sent all bytes to the UART before returning, but there would still be bytes in the UART that had not been sent, so it would return 1-11 bytes early

Fix: Used the UART_EVENT_TX_COMPLETE call back to determine when the UART has finished transmitting and use this to determine when flush() should return