### PR TITLE
Update USB.cpp for removing delays that is interfering to get high polling rate

### DIFF
--- a/cores/arduino/usb/USB.cpp
+++ b/cores/arduino/usb/USB.cpp
@@ -140,7 +140,7 @@ void __SetupUSBDescriptor() {
         uint8_t hid_itf = __USBInstallSerial ? 3 : 0;
         uint8_t hid_desc[TUD_HID_DESC_LEN] = {
             // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-            TUD_HID_DESCRIPTOR(hid_itf, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, USBD_HID_EP, CFG_TUD_HID_EP_BUFSIZE, 10)
+            TUD_HID_DESCRIPTOR(hid_itf, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, USBD_HID_EP, CFG_TUD_HID_EP_BUFSIZE, 0)
         };
 
         /*


### PR DESCRIPTION
Removed delay permitting higher polling rate mouses

Some users use this while gaming, and, today, gaming mouses can easily reach 8000mhz of polling rate, and setting a delay of 10, will stuck any mouse at 125hz