### PR TITLE
Clearing canvas buffer in ArduinoLEDMatrix::clear() in addition to frame buffer

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -260,6 +260,7 @@ public:
         	0x00000000
         };
         loadFrame(fullOff);
+        memset(_canvasBuffer, 0, sizeof(_canvasBuffer));
     }
 
 

--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -260,7 +260,9 @@ public:
         	0x00000000
         };
         loadFrame(fullOff);
+#ifdef MATRIX_WITH_ARDUINOGRAPHICS
         memset(_canvasBuffer, 0, sizeof(_canvasBuffer));
+#endif
     }
 
 


### PR DESCRIPTION
In the 1.2.0 update, the override of ArduinoLEDMatrix::clear() only cleared the frame buffer, but not the canvas buffer (Issue #336).
This resulted in pixels staying on in animations using matrix.beginDraw(), matrix.set(x, y, r, g, b), matrix.endDraw() even after a call to clear().