### PR TITLE
Fix in formula for creating frequency from MIDI note

### DIFF
--- a/libraries/AnalogWave/examples/DACEqualTemperedScale/DACEqualTemperedScale.ino
+++ b/libraries/AnalogWave/examples/DACEqualTemperedScale/DACEqualTemperedScale.ino
@@ -8,7 +8,7 @@
   a formula for converting MIDI note numbers (0-127) to pitches. This sketch
   reduces that to the notes 21 - 108, which are the 88 keys found on a piano:
 
-     frequency =  440 * ((noteNumber - 69) / 12.0)^2
+     frequency =  440 * 2^((noteNumber - 69) / 12.0)
 
   You can see this applied in the code below. 
 


### PR DESCRIPTION
The stated formula for converting midi-notes to frequency is wrong – the base and exponent of the second factor should be interchanged