### PR TITLE
WiFiS3: Skip unaligned responses from WiFi chip

### DIFF
--- a/libraries/WiFiS3/src/Modem.cpp
+++ b/libraries/WiFiS3/src/Modem.cpp
@@ -228,28 +228,36 @@ bool ModemClass::buf_read(const string &prompt, string &data_res) {
          }
          else {
             if(string::npos != data_res.rfind(RESULT_DATA)) {
-               found = true;
                data_res = data_res.substr(0, data_res.length() - (sizeof(RESULT_DATA) - 1));
                if(prompt != DO_NOT_CHECK_CMD) {
                   if(removeAtBegin(data_res, prompt)) {
                      res = true;
+                     found = true;
+                  } else {
+                     data_res.clear();
+                     continue;
                   }
                }
                else {
                  res = true;
+                 found = true;
                }
                break;  
             }
             else if(string::npos != data_res.rfind(RESULT_OK)){
-               found = true;
                data_res = data_res.substr(0, data_res.length() - (sizeof(RESULT_OK) - 1) );
                if(prompt != DO_NOT_CHECK_CMD) {
                   if(removeAtBegin(data_res, prompt)) {
                      res = true;
+                     found = true;
+                  } else {
+                     data_res.clear();
+                     continue;
                   }
                }
                else {
                  res = true;
+                 found = true;
                }
                break;
             } 


### PR DESCRIPTION
When network goes down (WiFi is up but no internet connection) AT message parsing gets corrupted due to late reply from WiFi chip. This PR fixes the issue discarding unaligned responses from WiFi chip .