### PR TITLE
Core renesas / Storage library, Fix for #366 (Name conflict in library Storage) 

### DIFF
--- a/libraries/BlockDevices/CodeFlashBlockDevice.cpp
+++ b/libraries/BlockDevices/CodeFlashBlockDevice.cpp
@@ -19,6 +19,9 @@
 
 #include "CodeFlashBlockDevice.h"
 
+#define debug_if rns_storage_dbg_if
+#define debug_mem rns_storage_dbg_mem
+
 // To enable debug set CF_DBG to 1 and make sure STORAGE_DEBUG is defined
 // in Storage/storage_common.h
 #define CF_DBG     0

--- a/libraries/BlockDevices/MBRBlockDevice.cpp
+++ b/libraries/BlockDevices/MBRBlockDevice.cpp
@@ -19,6 +19,9 @@
 #include <algorithm>
 #include <string.h>
 
+#define debug_if rns_storage_dbg_if
+#define debug_mem rns_storage_dbg_mem
+
 // To enable debug set MBR_DBG to 1 and make sure STORAGE_DEBUG is defined
 // in Storage/storage_common.h
 #define MBR_DBG     0

--- a/libraries/BlockDevices/QSPIFlashBlockDevice.cpp
+++ b/libraries/BlockDevices/QSPIFlashBlockDevice.cpp
@@ -19,6 +19,9 @@
 /* ########################################################################## */
 #include "QSPIFlashBlockDevice.h"
 
+#define debug_if rns_storage_dbg_if
+#define debug_mem rns_storage_dbg_mem
+
 #ifdef HAS_QSPI
 
 // To enable debug set QSPIF_DBG to 1 and make sure STORAGE_DEBUG is defined

--- a/libraries/FATFilesystem/FATFileSystem.cpp
+++ b/libraries/FATFilesystem/FATFileSystem.cpp
@@ -25,6 +25,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#define debug_if rns_storage_dbg_if
+
 //namespace mbed {
 
 //using namespace mbed;

--- a/libraries/Storage/storage_common.cpp
+++ b/libraries/Storage/storage_common.cpp
@@ -3,7 +3,7 @@
 
 #ifdef STORAGE_DEBUG
 
-char debug_buffer[STORAGE_BUFF_DIM];
+char rns_storage_dbg_buf[STORAGE_BUFF_DIM];
 
 #endif
 

--- a/libraries/Storage/storage_common.h
+++ b/libraries/Storage/storage_common.h
@@ -98,7 +98,7 @@ static inline void rns_storage_dbg_mem(uint8_t *b, uint32_t _size) {
 
 #ifdef STORAGE_ASSERT
     #define MBED_ASSERT(expr)  do { if (!(expr)) { \
-        debug("ASSERT FAILED at line %d in file %s",__LINE__,__FILE__); }} while(0)
+        rns_storage_dbg("ASSERT FAILED at line %d in file %s",__LINE__,__FILE__); }} while(0)
 #else
     #define MBED_ASSERT(expr)
 #endif 

--- a/libraries/Storage/storage_common.h
+++ b/libraries/Storage/storage_common.h
@@ -85,7 +85,7 @@ static inline void rns_storage_dbg(const char *format, ...) {
     (void)format;
 }
 
-static inline void _rns_storage_dbg_mem(uint8_t *b, uint32_t _size) {
+static inline void rns_storage_dbg_mem(uint8_t *b, uint32_t _size) {
     (void)b;
     (void)_size;
 }

--- a/libraries/Storage/storage_common.h
+++ b/libraries/Storage/storage_common.h
@@ -18,21 +18,21 @@ extern "C" {
 #define STORAGE_BUFF_DIM 512
 #define PRINT_SIZE        32
 
-extern char debug_buffer[STORAGE_BUFF_DIM];
+extern char rns_storage_dbg_buf[STORAGE_BUFF_DIM];
 
 /** Output a debug message
  *
  * @param format printf-style format string, followed by variables
  */
-static inline void debug(const char *fmt, ...)
+static inline void rns_storage_dbg(const char *fmt, ...)
 {
-    memset(debug_buffer,0x00,256);
+    memset(rns_storage_dbg_buf,0x00,256);
     va_list va;
     va_start (va, fmt);
-    vsnprintf (debug_buffer,STORAGE_BUFF_DIM, fmt, va);
+    vsnprintf (rns_storage_dbg_buf,STORAGE_BUFF_DIM, fmt, va);
     va_end (va);
     if(Serial)
-        Serial.println(debug_buffer);
+        Serial.println(rns_storage_dbg_buf);
 }
 
 
@@ -44,20 +44,20 @@ static inline void debug(const char *fmt, ...)
  * @param condition output only if condition is true (!= 0)
  * @param format printf-style format string, followed by variables
  */
-static inline void debug_if(int condition, const char *fmt, ...)
+static inline void rns_storage_dbg_if(int condition, const char *fmt, ...)
 {
     if (condition) {
-        memset(debug_buffer,0x00,256);
+        memset(rns_storage_dbg_buf,0x00,256);
         va_list va;
         va_start (va, fmt);
-        vsnprintf (debug_buffer,STORAGE_BUFF_DIM, fmt, va);
+        vsnprintf (rns_storage_dbg_buf,STORAGE_BUFF_DIM, fmt, va);
         va_end (va);
         if(Serial)
-            Serial.println(debug_buffer);
+            Serial.println(rns_storage_dbg_buf);
     }
 }
 
-static inline void debug_mem(uint8_t *b, uint32_t _size)
+static inline void rns_storage_dbg_mem(uint8_t *b, uint32_t _size)
 {
     if (b != nullptr) {
         Serial.println("");
@@ -76,16 +76,16 @@ static inline void debug_mem(uint8_t *b, uint32_t _size)
 
 #else
 
-static inline void debug_if(int condition, const char *format, ...) {
+static inline void rns_storage_dbg_if(int condition, const char *format, ...) {
     (void)condition;
     (void)format;
 }
 
-static inline void debug(const char *format, ...) {
+static inline void rns_storage_dbg(const char *format, ...) {
     (void)format;
 }
 
-static inline void debug_mem(uint8_t *b, uint32_t _size) {
+static inline void _rns_storage_dbg_mem(uint8_t *b, uint32_t _size) {
     (void)b;
     (void)_size;
 }


### PR DESCRIPTION
Renamed storage debug function to avoid clash with user code