### PR TITLE
Adding 9-bit support to the hardware serial UART

### DIFF
--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -341,27 +341,3 @@ size_t UART::write_raw(uint8_t* c, size_t len) {
   }
   return len;
 }
-
-/* -------------------------------------------------------------------------- */
-size_t UART::write_9bit(uint8_t c, bool wake) {
-/* -------------------------------------------------------------------------- */
-  uint16_t bit = 0x00;
-  if (wake) {bit = 0x100;}
-  uart_ctrl.p_reg->TDRHL = 0xFC00 + bit + c;
-  while (uart_ctrl.p_reg->SSR_b.TEND == 0) {}
-  return 1;
-}
-
-/* -------------------------------------------------------------------------- */
-size_t UART::write_9bit(uint8_t* c, bool wake, size_t len) {
-/* -------------------------------------------------------------------------- */
-  size_t i = 0;
-  uint16_t bit = 0x00;
-  if (wake) {bit = 0x100;}
-  while (i < len) {
-    uart_ctrl.p_reg->TDRHL = *(c+i) + 0xFC00 + bit; 
-    while (uart_ctrl.p_reg->SSR_b.TEND == 0) {}
-    i++;
-  }
-  return len;
-}

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -64,8 +64,6 @@ class UART : public arduino::HardwareSerial {
     size_t write(uint8_t c);
     size_t write(uint8_t* c, size_t len);
     size_t write_raw(uint8_t* c, size_t len);
-    size_t write_9bit(uint8_t c, bool wake);
-    size_t write_9bit(uint8_t* c, bool wake, size_t len);
     using Print::write; 
     operator bool(); // { return true; }
 

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -64,6 +64,8 @@ class UART : public arduino::HardwareSerial {
     size_t write(uint8_t c);
     size_t write(uint8_t* c, size_t len);
     size_t write_raw(uint8_t* c, size_t len);
+    size_t write_9bit(uint8_t c, bool wake);
+    size_t write_9bit(uint8_t* c, bool wake, size_t len);
     using Print::write; 
     operator bool(); // { return true; }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "framework-arduinorenesas-uno",
+  "version": "1.1.0",
+  "description": "Arduino Wiring-based Framework for Renesas MCUs (UNOR4 core)",
+  "keywords": [
+    "framework",
+    "arduino",
+    "renesas",
+    "RA"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arduino/ArduinoCore-renesas.git"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framework-arduinorenesas-uno",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Arduino Wiring-based Framework for Renesas MCUs (UNOR4 core)",
   "keywords": [
     "framework",
@@ -10,6 +10,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/arduino/ArduinoCore-renesas.git"
+    "url": "https://github.com/vashadow/ArduinoCore-renesas.git"
   }
 }


### PR DESCRIPTION
The new UNO R4 WIFI supports 9-bit operations on the hardware UART as per page 28.2.6 of the Renesas RA4M1 Groups: User Manual: Hardware. 

[https://forum.arduino.cc/t/9-bit-uart-is-built-in-to-the-new-ra4m1-chips/1310858](url)

There has also been a pull request to the API HardwareSerial.h file to allow for 9N1. These changes effectively put the UART into 9-bit mode and allow transmitting from the UART TDRHL 16-bit register with and without the 9th bit (wake bit) being set. 

The second argument allows for turning on or off the wake bit. TRUE = wake bit set to 1   FALSE = wake bit set to 0

Example command use:
Serial1.begin(19200, SERIAL_9N1);
Serial1.write_9bit(temp[0], true);
Serial1.write_9bit(&temp[1], false, len - 1);

UPDATE:
Removed the write_9bit commands in favor of using the native write command in byte array mode:

uint16_t d[] = {0xFF01, 0xFC8A, 0xFC00, 0xFC23};
Serial1.write((uint8_t *)d, sizeof(d));