### PR TITLE
Add limit for returning the first 10 access points with high rssi

### DIFF
--- a/libraries/WiFiS3/src/WiFi.cpp
+++ b/libraries/WiFiS3/src/WiFi.cpp
@@ -1,7 +1,5 @@
 #include "WiFi.h"
 
-#define SSID_MAX_COUNT 12
-
 using namespace std;
 
 /* -------------------------------------------------------------------------- */

--- a/libraries/WiFiS3/src/WiFi.h
+++ b/libraries/WiFiS3/src/WiFi.h
@@ -19,9 +19,9 @@
 
 #define WIFI_FIRMWARE_LATEST_VERSION "0.5.2"
 
-#define WL_MAX_AP_LIST 10
-#define WL_MAX_BSSID_LENGTH 17
-#define WL_MAX_SSID_LENGHT_S WL_SSID_MAX_LENGTH + 1 // +1 for null terminator
+#ifndef WIFI_MAX_SSID_COUNT
+  #define WIFI_MAX_SSID_COUNT 10
+#endif
 
 class CAccessPoint {
 public:
@@ -41,7 +41,7 @@ public:
         encryption_mode = obj.encryption_mode;
         memcpy(uint_bssid, obj.uint_bssid, sizeof(uint_bssid));
     }
-    char ssid[WL_MAX_SSID_LENGHT_S];
+    char ssid[WL_SSID_MAX_LENGTH + 1]; // +1 for null terminator
     uint8_t uint_bssid[6];
     int rssi;
     uint8_t channel;
@@ -54,7 +54,7 @@ private:
     void _config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2);
     void _sortAPlist(uint8_t num);
     unsigned long _timeout;
-    CAccessPoint access_points[WL_MAX_AP_LIST];
+    CAccessPoint access_points[WIFI_MAX_SSID_COUNT];
     uint8_t _apsFound = 0;
     std::string ssid;
     std::string apssid;

--- a/libraries/WiFiS3/src/WiFi.h
+++ b/libraries/WiFiS3/src/WiFi.h
@@ -19,24 +19,43 @@
 
 #define WIFI_FIRMWARE_LATEST_VERSION "0.5.2"
 
+#define WL_MAX_AP_LIST 10
+#define WL_MAX_BSSID_LENGTH 17
+#define WL_MAX_SSID_LENGHT_S WL_SSID_MAX_LENGTH + 1 // +1 for null terminator
+
 class CAccessPoint {
 public:
-    std::string ssid;
-    std::string bssid;
+    CAccessPoint() {}
+    CAccessPoint(const CAccessPoint &obj)
+    {
+        strcpy(ssid, obj.ssid);
+        rssi = obj.rssi;
+        channel = obj.channel;
+        encryption_mode = obj.encryption_mode;
+        memcpy(uint_bssid, obj.uint_bssid, sizeof(uint_bssid));
+    }
+    CAccessPoint &operator=(const CAccessPoint &obj) {
+        strcpy(ssid, obj.ssid);
+        rssi = obj.rssi;
+        channel = obj.channel;
+        encryption_mode = obj.encryption_mode;
+        memcpy(uint_bssid, obj.uint_bssid, sizeof(uint_bssid));
+    }
+    char ssid[WL_MAX_SSID_LENGHT_S];
     uint8_t uint_bssid[6];
-    std::string rssi;
-    std::string channel;
-    std::string encryption_mode;
+    int rssi;
+    uint8_t channel;
+    uint8_t encryption_mode;
 };
-
-
 
 
 class CWifi {
 private:
     void _config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2);
+    void _sortAPlist(uint8_t num);
     unsigned long _timeout;
-    std::vector<CAccessPoint> access_points;
+    CAccessPoint access_points[WL_MAX_AP_LIST];
+    uint8_t _apsFound = 0;
     std::string ssid;
     std::string apssid;
 


### PR DESCRIPTION
During the `WiFi.scanNetworks()` the access points found are stored on a `vector `container. 

The allocation of memory for the `vector` doesn't grow linearly with the increasing of data stored, but logarithmically (view [this ](https://cplusplus.com/reference/vector/vector/) ) and this can hang up the Arduino UNO R4 board for memory saturation when performing a scan inside an enviroment with many APs.

This PR limits the number of element stored inside the vector for returning only the APs with the highest RSSI.