### PR TITLE
SerialX.begin - support 7 bit modes.

### DIFF
--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -260,6 +260,38 @@ void UART::begin(unsigned long baudrate, uint16_t config) {
           uart_cfg.parity = UART_PARITY_ODD;
           uart_cfg.stop_bits = UART_STOP_BITS_2;
           break;
+      // add 7 bit support
+      case SERIAL_7N1:
+          uart_cfg.data_bits = UART_DATA_BITS_7;
+          uart_cfg.parity = UART_PARITY_OFF;
+          uart_cfg.stop_bits = UART_STOP_BITS_1;
+          break;
+      case SERIAL_7N2:
+          uart_cfg.data_bits = UART_DATA_BITS_7;
+          uart_cfg.parity = UART_PARITY_OFF;
+          uart_cfg.stop_bits = UART_STOP_BITS_2;
+          break;
+      case SERIAL_7E1:
+          uart_cfg.data_bits = UART_DATA_BITS_7;
+          uart_cfg.parity = UART_PARITY_EVEN;
+          uart_cfg.stop_bits = UART_STOP_BITS_1;
+          break;
+      case SERIAL_7E2:
+          uart_cfg.data_bits = UART_DATA_BITS_7;
+          uart_cfg.parity = UART_PARITY_EVEN;
+          uart_cfg.stop_bits = UART_STOP_BITS_2;
+          break;
+      case SERIAL_7O1:
+          uart_cfg.data_bits = UART_DATA_BITS_7;
+          uart_cfg.parity = UART_PARITY_ODD;
+          uart_cfg.stop_bits = UART_STOP_BITS_1;
+          break;
+      case SERIAL_7O2:
+          uart_cfg.data_bits = UART_DATA_BITS_7;
+          uart_cfg.parity = UART_PARITY_ODD;
+          uart_cfg.stop_bits = UART_STOP_BITS_2;
+          break;
+
     }
     
     uart_cfg.p_callback = UART::WrapperCallback;


### PR DESCRIPTION
As per the forum thread:
https://forum.arduino.cc/t/uno-r4-and-serial1-different-nr-databits/1192974/9

Sketches that tried to use the standard modes such as Serial_7E1 Would not work and sounds like they would hang.

This sketch simply duplicated the 8 bit modes, in the switch statement, and changed _8 to _7... So for example:
```
     case SERIAL_7E1:
          uart_cfg.data_bits = UART_DATA_BITS_7;
          uart_cfg.parity = UART_PARITY_EVEN;
          uart_cfg.stop_bits = UART_STOP_BITS_1;
          break;
```
There was already support for handling this in the FSP layer. I verified that 7E1 and 7O1 worked using logic analyzer.  Also verified that the standard 8N1 still worked.

Note: The ArduinoCore-API file HardwareSerial.h has many other defined modes, which are probably
not supported, on the UNO R4, such as: SERIAL_5E2

Which the switch statement still does not handle, and the uart_cfg items will not be set... But that is beyond this fix.