### PR TITLE
Initialize local variable for AP config

### DIFF
--- a/libraries/ESPhost/examples/ESP32_TEST/ESP32_TEST.ino
+++ b/libraries/ESPhost/examples/ESP32_TEST/ESP32_TEST.ino
@@ -297,7 +297,7 @@ void connectAccessPoint() {
     int i = stoi(ap_str);
     
     Serial.println(">>> [APP]: Connecting to Access Point");
-    WifiApCfg_t ap;
+    WifiApCfg_t ap{};
     memcpy(ap.ssid,access_point_list[i].ssid,SSID_LENGTH);
     memcpy(ap.pwd,pwd.c_str(),pwd.size());
     memcpy(ap.bssid,access_point_list[i].bssid,BSSID_LENGTH);


### PR DESCRIPTION
The AP configuration variable wasn't initialized, so the fields contained random data. Then, they were filled using memcpy() with the size of the data to copy, leaving the remainder of the fields containing random data. For example, the pwd variable containing the entered password was copied without null termination into the pwd field, and the rest of the pwd field contained random data. This caused connection failures depending on the content of the random data.