### PR TITLE
Add Non-blocking Version of localIP Function for WiFiS3 library and fix FifoBuffer.h

### DIFF
--- a/cores/arduino/FifoBuffer.h
+++ b/cores/arduino/FifoBuffer.h
@@ -27,7 +27,6 @@
 
 namespace arduino {
 
-
 #define FIFO_DEFAULT_SIZE 64
 
 template <typename T, uint32_t size = FIFO_DEFAULT_SIZE>
@@ -38,28 +37,30 @@ class FifoBuffer
       synchronized {
         return (uint32_t)(index + 1) % size;
       }
+      return 0; // Fallback return
     }
+
     inline bool isEmpty() const { return (_numElems == 0); }
-    T _aucBuffer[size] ;
-    uint32_t _iHead ;
-    uint32_t _iTail ;
+    T _aucBuffer[size];
+    uint32_t _iHead;
+    uint32_t _iTail;
     uint32_t _numElems;
+
   public:
     /* ---------------------------------------------------------------------- */
-    FifoBuffer( void ) {
-      memset( _aucBuffer, 0, size * sizeof(T) ) ;
+    FifoBuffer(void) {
+      memset(_aucBuffer, 0, size * sizeof(T));
       clear();
     }
     /* ---------------------------------------------------------------------- */
-    bool store( T c ) {
+    bool store(T c) {
       bool rv = true;
       synchronized {
         if (!isFull()) {
-          _aucBuffer[_iHead] = c ;
+          _aucBuffer[_iHead] = c;
           _iHead = nextIndex(_iHead);
           _numElems++;
-        }
-        else {
+        } else {
           rv = false;
         }
       }
@@ -72,36 +73,39 @@ class FifoBuffer
       _numElems = 0;
     }
     /* ---------------------------------------------------------------------- */
-    T read(bool *read_ok) {
+    T read(bool* read_ok) {
       *read_ok = true;
       if (isEmpty()) {
         *read_ok = false;
-        return _aucBuffer[0];
+        return T(); // Return default-constructed object
       }
       synchronized {
         T value = _aucBuffer[_iTail];
         _iTail = nextIndex(_iTail);
         _numElems--;
-      
+
         return value;
       }
+      return T(); // Fallback return
     }
     /* ---------------------------------------------------------------------- */
     int available() {
       synchronized {
         return _numElems;
       }
+      return 0; // Fallback return
     }
     /* ---------------------------------------------------------------------- */
     int freePositions() {
       synchronized {
         return (size - _numElems);
       }
+      return 0; // Fallback return
     }
     /* ---------------------------------------------------------------------- */
     T peek() {
       if (isEmpty())
-        return -1;
+        return T(); // Return default-constructed object
 
       return _aucBuffer[_iTail];
     }
@@ -110,15 +114,13 @@ class FifoBuffer
       synchronized {
         return (_numElems == size);
       }
+      return false; // Fallback return
     }
     /* ---------------------------------------------------------------------- */
-    uint32_t lenght()  const { return size; }
-
-  
+    uint32_t lenght() const { return size; }
 };
 
-
-} //namespace arduino
+} // namespace arduino
 
 #endif /* _ARDUINO_FIFO_BUFFER_DH_ */
 #endif /* __cplusplus */

--- a/libraries/WiFiS3/src/WiFi.cpp
+++ b/libraries/WiFiS3/src/WiFi.cpp
@@ -356,6 +356,29 @@ IPAddress CWifi::localIP() {
    return local_IP;
 }
 
+IPAddress CWifi::localIPNonBlocking(unsigned long timeoutMs) {
+    modem.begin();
+    string res = "";
+    unsigned long start = millis();
+    IPAddress local_IP(0, 0, 0, 0);
+
+    while (local_IP == IPAddress(0, 0, 0, 0) && millis() - start < timeoutMs) {
+        if (modem.write(string(PROMPT(_MODE)), res, "%s", CMD_READ(_MODE))) {
+            if (atoi(res.c_str()) == 1) {
+                if (modem.write(string(PROMPT(_IPSTA)), res, "%s%d\\r\\n", CMD_WRITE(_IPSTA), IP_ADDR)) {
+                    local_IP.fromString(res.c_str());
+                }
+            } else if (atoi(res.c_str()) == 2) {
+                if (modem.write(string(PROMPT(_IPSOFTAP)), res, CMD(_IPSOFTAP))) {
+                    local_IP.fromString(res.c_str());
+                }
+            }
+        }
+    }
+    return local_IP;
+}
+
+
 /* -------------------------------------------------------------------------- */
 IPAddress CWifi::subnetMask() {
 /* -------------------------------------------------------------------------- */

--- a/libraries/WiFiS3/src/WiFi.h
+++ b/libraries/WiFiS3/src/WiFi.h
@@ -175,7 +175,8 @@ public:
      * return: IP address value
      */
     IPAddress localIP();
-
+    IPAddress localIPNonBlocking(unsigned long timeoutMs);
+    
     /*
      * Get the interface subnet mask address.
      *


### PR DESCRIPTION
This PR introduces a non-blocking version of the localIP function, named localIPNonBlocking, to the WiFi.cpp file. The new function addresses situations where the current localIP implementation, which uses a blocking delay(100) call, can cause issues such as triggering a watchdog timer (WDT).

This PR also solves:
- #406

### New Function: `localIPNonBlocking`
Added to libraries/WiFiS3/src/WiFi.cpp at line 357 (after the existing localIP implementation).
Utilizes a timeout mechanism with millis() to avoid blocking delays.
Returns the device's local IP address or a default address (0.0.0.0) if the timeout expires.

### Example Usage:
```
unsigned long timeout = 5000; // 5-second timeout
IPAddress ip = WiFi.localIPNonBlocking(timeout);

if (ip) {
    Serial.println(ip); // Print the IP if successfully retrieved
} else {
    Serial.println("Failed to get IP within the timeout period");
}

```
