### PR TITLE
Allow FreeRTOS hook for C33 only and improve its reliability

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -12,7 +12,7 @@ portenta_c33.build.fpu=-mfpu=fpv5-sp-d16
 portenta_c33.build.float-abi=-mfloat-abi=hard
 
 portenta_c33.build.board=PORTENTA_C33
-portenta_c33.build.defines=-DF_CPU=200000000
+portenta_c33.build.defines=-DF_CPU=200000000 -DPROVIDE_FREERTOS_HOOK
 portenta_c33.vid.0=0x2341
 portenta_c33.pid.0=0x0068
 portenta_c33.vid.1=0x2341

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -113,7 +113,9 @@ void arduino_main(void)
 #endif
    startAgt();
    setup();
+#ifdef PROVIDE_FREERTOS_HOOK
    start_freertos_on_header_inclusion();
+#endif
    while (1)
    {
       loop();

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -112,8 +112,8 @@ void arduino_main(void)
    Serial.begin(115200);
 #endif
    startAgt();
-   start_freertos_on_header_inclusion();
    setup();
+   start_freertos_on_header_inclusion();
    while (1)
    {
       loop();

--- a/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
+++ b/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
@@ -226,7 +226,6 @@ static void prvTaskExitError(void);
 #endif
 
 void loop_thread_func(void* arg) {
-    setup();
     while (1)
     {
         loop();


### PR DESCRIPTION
Fixes concerns from https://github.com/arduino/ArduinoCore-renesas/pull/369#issuecomment-2519980477

@pennam @hexnet1234 @gpb01