### PR TITLE
Add a missing linefeed with a println.

### DIFF
--- a/libraries/WiFiS3/examples/ScanNetworks/ScanNetworks.ino
+++ b/libraries/WiFiS3/examples/ScanNetworks/ScanNetworks.ino
@@ -91,7 +91,7 @@ void printEncryptionType(int thisType) {
       Serial.println("WPA2");
       break;
     case ENC_TYPE_WPA3:
-      Serial.print("WPA3");
+      Serial.println("WPA3");
       break;   
     case ENC_TYPE_NONE:
       Serial.println("None");


### PR DESCRIPTION
There is a very minor issue in the ScanNetworks example.
A linefeed for networks with the encryption type WPA3.
This results in the following output:

```
Scanning available networks...
** Scan Networks **
number of available networks:7

0) Aloha Signal: -53 dBm Encryption: WPA2
1) Coral Signal: -67 dBm Encryption: WPA2
2) Attwifi Signal: -75 dBm Encryption: WPA2
3) Zambo Signal: -86 dBm Encryption: WPA34) weiyi Signal: -88 dBm Encryption: WPA2
5) weiyi-guest Signal: -89 dBm Encryption: WPA2
6) 2WIRE049 Signal: -92 dBm Encryption: WPA2
```

Changing the print to println for WPA3 fixes the issue:
```
Scanning available networks...
** Scan Networks **
number of available networks:7

0) Aloha Signal: -53 dBm Encryption: WPA2
1) Coral Signal: -67 dBm Encryption: WPA2
2) Attwifi Signal: -75 dBm Encryption: WPA2
3) Zambo Signal: -86 dBm Encryption: WPA3
4) weiyi Signal: -88 dBm Encryption: WPA2
5) weiyi-guest Signal: -89 dBm Encryption: WPA2
6) 2WIRE049 Signal: -92 dBm Encryption: WPA2
```