### PR TITLE
UNO R4 WiFi Fix firmware init from cold boot

### DIFF
--- a/libraries/WiFiS3/src/Modem.cpp
+++ b/libraries/WiFiS3/src/Modem.cpp
@@ -36,7 +36,9 @@ void ModemClass::begin(int badurate){
       _serial->begin(badurate);
       string res = "";
       _serial->flush();
+      modem.timeout(500);
       beginned = modem.write(string(PROMPT(_SOFTRESETWIFI)),res, "%s" , CMD(_SOFTRESETWIFI));
+      modem.timeout(MODEM_TIMEOUT);
    }
 }
 

--- a/libraries/WiFiS3/src/Modem.cpp
+++ b/libraries/WiFiS3/src/Modem.cpp
@@ -34,10 +34,9 @@ void ModemClass::begin(int badurate){
 /* -------------------------------------------------------------------------- */
    if(_serial != nullptr && !beginned) {
       _serial->begin(badurate);
-      beginned = true;
       string res = "";
       _serial->flush();
-      modem.write(string(PROMPT(_SOFTRESETWIFI)),res, "%s" , CMD(_SOFTRESETWIFI));
+      beginned = modem.write(string(PROMPT(_SOFTRESETWIFI)),res, "%s" , CMD(_SOFTRESETWIFI));
    }
 }
 

--- a/libraries/WiFiS3/src/Modem.cpp
+++ b/libraries/WiFiS3/src/Modem.cpp
@@ -30,14 +30,17 @@ ModemClass::~ModemClass() {
 }
 
 /* -------------------------------------------------------------------------- */
-void ModemClass::begin(int badurate){
+void ModemClass::begin(int badurate, int retry){
 /* -------------------------------------------------------------------------- */
    if(_serial != nullptr && !beginned) {
       _serial->begin(badurate);
       string res = "";
       _serial->flush();
       modem.timeout(500);
-      beginned = modem.write(string(PROMPT(_SOFTRESETWIFI)),res, "%s" , CMD(_SOFTRESETWIFI));
+      while(!beginned && retry > 0) {
+         beginned = modem.write(string(PROMPT(_SOFTRESETWIFI)),res, "%s" , CMD(_SOFTRESETWIFI));
+         retry -= 1;
+      }
       modem.timeout(MODEM_TIMEOUT);
    }
 }

--- a/libraries/WiFiS3/src/Modem.h
+++ b/libraries/WiFiS3/src/Modem.h
@@ -22,7 +22,7 @@ public:
   ModemClass(UART * _serial);
   ~ModemClass();
 
-  void begin(int badurate = 115200);
+  void begin(int badurate = 115200, int retry = 3);
   void end();
   bool write(const std::string &cmd, std::string &str, const char * fmt, ...);
   void write_nowait(const std::string &cmd, std::string &str, const char * fmt, ...);


### PR DESCRIPTION
During coldboot first attempt of `_SOFTRESETWIFI` always fails. This patch is to mitigate the issue. Investigation fwside will follow.

