### PR TITLE
WiFiS3 and WiFIC3 Add wl definitions

### DIFF
--- a/libraries/WiFiS3/src/WiFi.h
+++ b/libraries/WiFiS3/src/WiFi.h
@@ -17,9 +17,7 @@
 #define DEFAULT_GW_AP_ADDRESS           IPAddress(192,168,1,1)
 #define DEFAULT_NM_AP_ADDRESS           IPAddress(255,255,255,0)
 
-
 #define WIFI_FIRMWARE_LATEST_VERSION "0.4.1"
-#define WL_MAC_ADDR_LENGTH 6
 
 class CAccessPoint {
 public:

--- a/libraries/WiFiS3/src/WiFiTypes.h
+++ b/libraries/WiFiS3/src/WiFiTypes.h
@@ -9,7 +9,7 @@
 #define WL_WEP_KEY_MAX_LENGTH 13
 // Size of a MAC-address or BSSID
 #define WL_MAC_ADDR_LENGTH 6
-// Size of a MAC-address or BSSID
+// Size of a IP4 address
 #define WL_IPV4_LENGTH 4
 
 typedef enum {

--- a/libraries/WiFiS3/src/WiFiTypes.h
+++ b/libraries/WiFiS3/src/WiFiTypes.h
@@ -1,19 +1,30 @@
 #ifndef WIFI_S3_TYPES_H
 #define WIFI_S3_TYPES_H
 
+// Maximum size of a SSID
+#define WL_SSID_MAX_LENGTH 32
+// Length of passphrase. Valid lengths are 8-63.
+#define WL_WPA_KEY_MAX_LENGTH 63
+// Length of key in bytes. Valid values are 5 and 13.
+#define WL_WEP_KEY_MAX_LENGTH 13
+// Size of a MAC-address or BSSID
+#define WL_MAC_ADDR_LENGTH 6
+// Size of a MAC-address or BSSID
+#define WL_IPV4_LENGTH 4
+
 typedef enum {
-   WL_NO_SHIELD = 255,
-        WL_NO_MODULE = WL_NO_SHIELD,
-        WL_IDLE_STATUS = 0,
-        WL_NO_SSID_AVAIL,
-        WL_SCAN_COMPLETED,
-        WL_CONNECTED,
-        WL_CONNECT_FAILED,
-        WL_CONNECTION_LOST,
-        WL_DISCONNECTED,
-        WL_AP_LISTENING,
-        WL_AP_CONNECTED,
-        WL_AP_FAILED
+    WL_NO_SHIELD = 255,
+    WL_NO_MODULE = WL_NO_SHIELD,
+    WL_IDLE_STATUS = 0,
+    WL_NO_SSID_AVAIL,
+    WL_SCAN_COMPLETED,
+    WL_CONNECTED,
+    WL_CONNECT_FAILED,
+    WL_CONNECTION_LOST,
+    WL_DISCONNECTED,
+    WL_AP_LISTENING,
+    WL_AP_CONNECTED,
+    WL_AP_FAILED
 } wl_status_t;
 
 /* Encryption modes */
@@ -27,15 +38,14 @@ enum wl_enc_type {
     ENC_TYPE_WPA3,
     ENC_TYPE_NONE,
     ENC_TYPE_AUTO,
-
     ENC_TYPE_UNKNOWN = 255
 };
 
 typedef enum {
-  WL_PING_DEST_UNREACHABLE = -1,
-  WL_PING_TIMEOUT = -2,
-  WL_PING_UNKNOWN_HOST = -3,
-  WL_PING_ERROR = -4
-} wl_ping_result_t;
+    WL_PING_DEST_UNREACHABLE = -1,
+    WL_PING_TIMEOUT = -2,
+    WL_PING_UNKNOWN_HOST = -3,
+    WL_PING_ERROR = -4
+}wl_ping_result_t;
 
 #endif

--- a/libraries/lwIpWrapper/src/CNetIf.cpp
+++ b/libraries/lwIpWrapper/src/CNetIf.cpp
@@ -537,17 +537,17 @@ int CLwipIf::getMacAddress(NetIfType_t type, uint8_t* mac)
         MAC.mode = WIFI_MODE_STA;
         if (CEspControl::getInstance().getWifiMacAddress(MAC) == ESP_CONTROL_OK) {
             CNetUtilities::macStr2macArray(mac, MAC.mac);
-            rv = MAC_ADDRESS_DIM;
+            rv = WL_MAC_ADDR_LENGTH;
         }
     } else if (type == NI_WIFI_SOFTAP) {
         MAC.mode = WIFI_MODE_AP;
         if (CEspControl::getInstance().getWifiMacAddress(MAC) == ESP_CONTROL_OK) {
             CNetUtilities::macStr2macArray(mac, MAC.mac);
-            rv = MAC_ADDRESS_DIM;
+            rv = WL_MAC_ADDR_LENGTH;
         }
     } else {
         eth_get_mac_address(mac);
-        rv = MAC_ADDRESS_DIM;
+        rv = WL_MAC_ADDR_LENGTH;
     }
 
     CLwipIf::getInstance().restartAsyncRequest();

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -34,14 +34,21 @@
 #endif
 
 #define MAX_SOFAT_CONNECTION_DEF 5
-
-#define MAC_ADDRESS_DIM 6
 #define NETWORK_INTERFACES_MAX_NUM 3
 #define MAX_HOSTNAME_DIM 253
 
 #define WIFI_INIT_TIMEOUT_MS 10000
 
+// Maximum size of a SSID
+#define WL_SSID_MAX_LENGTH 32
+// Length of passphrase. Valid lengths are 8-63.
+#define WL_WPA_KEY_MAX_LENGTH 63
+// Length of key in bytes. Valid values are 5 and 13.
+#define WL_WEP_KEY_MAX_LENGTH 13
+// Size of a MAC-address or BSSID
 #define WL_MAC_ADDR_LENGTH 6
+// Size of a MAC-address or BSSID
+#define WL_IPV4_LENGTH 4
 
 /* DEFAULT ADDRESS FOR ETHERNET CONFIGURATION */
 

--- a/libraries/lwIpWrapper/src/CNetIf.h
+++ b/libraries/lwIpWrapper/src/CNetIf.h
@@ -47,7 +47,7 @@
 #define WL_WEP_KEY_MAX_LENGTH 13
 // Size of a MAC-address or BSSID
 #define WL_MAC_ADDR_LENGTH 6
-// Size of a MAC-address or BSSID
+// Size of a IP4 address
 #define WL_IPV4_LENGTH 4
 
 /* DEFAULT ADDRESS FOR ETHERNET CONFIGURATION */


### PR DESCRIPTION
Fixes: #294 

I've added only WL*_LENGTH definitions because even though they are mostly unused they are handy to declare arrays as explained in the issue.