### PR TITLE
BlockDevices: minor fixes to cleanup compile warnings

### DIFF
--- a/libraries/BlockDevices/QSPIFlashBlockDevice.cpp
+++ b/libraries/BlockDevices/QSPIFlashBlockDevice.cpp
@@ -287,7 +287,7 @@ int QSPIFlashBlockDevice::write(const void *buffer, bd_addr_t add, bd_size_t _si
       R_QSPI_BankSet(&ctrl, bank);
       rv = R_QSPI_Write(&ctrl, (uint8_t *)(buffer), (uint8_t*)address, chunk);
       address += chunk;
-      buffer += chunk;
+      buffer = (uint8_t *)(buffer) + chunk;
 
       if(rv == FSP_SUCCESS) {
          rv = get_flash_status();

--- a/libraries/BlockDevices/QSPIFlashBlockDevice.cpp
+++ b/libraries/BlockDevices/QSPIFlashBlockDevice.cpp
@@ -328,7 +328,7 @@ int QSPIFlashBlockDevice::erase(bd_addr_t add, bd_size_t _size) {
 
    uint32_t num_of_blocks = (_size / erase_block_size);
 
-   for(int i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
+   for(uint32_t i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
       /* set bank */
       uint32_t bank = add / READ_PAGE_SIZE;  
       uint32_t address = base_address + ((add + i * erase_block_size) % READ_PAGE_SIZE);  

--- a/libraries/BlockDevices/QSPIFlashBlockDevice.h
+++ b/libraries/BlockDevices/QSPIFlashBlockDevice.h
@@ -70,25 +70,27 @@
 
 class QSPIFlashBlockDevice : public BlockDevice {
 private:
-  bool opened;
-  
-  bd_addr_t base_address;
-  bd_size_t total_size;
-  bd_size_t read_block_size;
-  bd_size_t erase_block_size;
-  bd_size_t write_block_size;
 
-  bool is_address_correct(bd_addr_t add);
-
-  qspi_instance_ctrl_t  ctrl;
-  spi_flash_cfg_t       cfg;
-  qspi_extended_cfg_t   ext_cfg;
   pin_t ck;
   pin_t cs;
   pin_t io0;
   pin_t io1;
   pin_t io2;
   pin_t io3;
+
+  bd_addr_t base_address;
+  bd_size_t total_size;
+  bd_size_t read_block_size;
+  bd_size_t erase_block_size;
+  bd_size_t write_block_size;
+
+  bool opened;
+
+  bool is_address_correct(bd_addr_t add);
+
+  qspi_instance_ctrl_t  ctrl;
+  spi_flash_cfg_t       cfg;
+  qspi_extended_cfg_t   ext_cfg;
 
   fsp_err_t get_flash_status();
 

--- a/libraries/BlockDevices/SDCardBlockDevice.cpp
+++ b/libraries/BlockDevices/SDCardBlockDevice.cpp
@@ -166,7 +166,6 @@ SDCardBlockDevice::~SDCardBlockDevice() {
 /*                               CALLBACK                                     */
 /* -------------------------------------------------------------------------- */
 void SDCardBlockDevice::SDCardBlockDeviceCbk(sdmmc_callback_args_t *arg) {
-   int open_status = -1;
    if(arg != nullptr) {
       sdmmc_event_t event = arg->event;
 

--- a/libraries/BlockDevices/SDCardBlockDevice.cpp
+++ b/libraries/BlockDevices/SDCardBlockDevice.cpp
@@ -368,7 +368,8 @@ int SDCardBlockDevice::read(void *buffer, bd_addr_t add, bd_size_t _size) {
          uint32_t start_add_of_block = (add / read_block_size);
          rv = FSP_SUCCESS;
          for(uint32_t i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
-            rv = R_SDHI_Read (&ctrl, (uint8_t *)((uint8_t *)buffer + (i * read_block_size)), start_add_of_block + i, 1);
+           uint8_t *buf = (uint8_t *)buffer;
+            rv = R_SDHI_Read (&ctrl, buf + (i * read_block_size), start_add_of_block + i, 1);
             if(rv == FSP_SUCCESS) {
                rv = wait_for_completition();
             }

--- a/libraries/BlockDevices/SDCardBlockDevice.cpp
+++ b/libraries/BlockDevices/SDCardBlockDevice.cpp
@@ -367,8 +367,8 @@ int SDCardBlockDevice::read(void *buffer, bd_addr_t add, bd_size_t _size) {
          uint32_t num_of_blocks = (_size / read_block_size);
          uint32_t start_add_of_block = (add / read_block_size);
          rv = FSP_SUCCESS;
-         for(int i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
-            rv = R_SDHI_Read (&ctrl, (uint8_t *)(buffer + (i * read_block_size)), start_add_of_block + i, 1);
+         for(uint32_t i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
+            rv = R_SDHI_Read (&ctrl, (uint8_t *)((uint8_t *)buffer + (i * read_block_size)), start_add_of_block + i, 1);
             if(rv == FSP_SUCCESS) {
                rv = wait_for_completition();
             }
@@ -403,8 +403,8 @@ int SDCardBlockDevice::write(const void *buffer, bd_addr_t add, bd_size_t _size)
          uint32_t num_of_blocks = (_size / write_block_size);
          uint32_t start_block_number = (add / write_block_size);
          rv = FSP_SUCCESS;
-         for(int i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
-            rv = R_SDHI_Write (&ctrl, (uint8_t *)(buffer + (i * write_block_size)), start_block_number + i, 1);
+         for(uint32_t i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
+            rv = R_SDHI_Write (&ctrl, (uint8_t *)((uint8_t *)buffer + (i * write_block_size)), start_block_number + i, 1);
             if(rv == FSP_SUCCESS) {
                rv = wait_for_completition();
             }
@@ -438,7 +438,7 @@ int SDCardBlockDevice::erase(bd_addr_t add, bd_size_t _size) {
          uint32_t num_of_blocks = (_size / erase_block_size);
          uint32_t start_block_number = (add / erase_block_size);
          rv = FSP_SUCCESS;
-         for(int i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
+         for(uint32_t i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
             rv = R_SDHI_Erase (&ctrl, start_block_number + i, 1);
             if(rv == FSP_SUCCESS) {
                rv = wait_for_completition();

--- a/libraries/BlockDevices/SDCardBlockDevice.cpp
+++ b/libraries/BlockDevices/SDCardBlockDevice.cpp
@@ -405,7 +405,8 @@ int SDCardBlockDevice::write(const void *buffer, bd_addr_t add, bd_size_t _size)
          uint32_t start_block_number = (add / write_block_size);
          rv = FSP_SUCCESS;
          for(uint32_t i = 0; i < num_of_blocks && rv == FSP_SUCCESS; i++) {
-            rv = R_SDHI_Write (&ctrl, (uint8_t *)((uint8_t *)buffer + (i * write_block_size)), start_block_number + i, 1);
+            uint8_t *buf = (uint8_t *)buffer;
+            rv = R_SDHI_Write (&ctrl, buf + (i * write_block_size), start_block_number + i, 1);
             if(rv == FSP_SUCCESS) {
                rv = wait_for_completition();
             }

--- a/libraries/BlockDevices/SDCardBlockDevice.h
+++ b/libraries/BlockDevices/SDCardBlockDevice.h
@@ -60,13 +60,22 @@ enum class CmdStatus {
 
 class SDCardBlockDevice : public BlockDevice {
 private:
-  sdmmc_device_t sd_card_info;
+  pin_t ck;
+  pin_t cmd;
+  pin_t d0;
+  pin_t d1;
+  pin_t d2;
+  pin_t d3;
+  pin_t cd;
+  pin_t wp;
   bd_addr_t base_address;
   bd_size_t total_size;
   bd_size_t read_block_size;
   bd_size_t erase_block_size;
   bd_size_t write_block_size;
+  bool opened;
   sdhi_instance_ctrl_t  ctrl;
+  sdmmc_device_t sd_card_info;
   sdmmc_cfg_t           cfg;
   
   #ifdef USE_DMAC
@@ -84,14 +93,7 @@ private:
   transfer_cfg_t        dtc_cfg;
   transfer_instance_t   dtc_instance;
   #endif
-  pin_t ck;
-  pin_t cmd;
-  pin_t d0;
-  pin_t d1;
-  pin_t d2;
-  pin_t d3;
-  pin_t cd;
-  pin_t wp;
+
   static volatile bool initialized;
   static volatile bool card_inserted;
   static volatile CmdStatus st;
@@ -99,7 +101,7 @@ private:
   virtual int write(const void *buffer, bd_addr_t addr, bd_size_t size) override;
   virtual int open() override;
   virtual int close() override;
-  bool opened;
+
   fsp_err_t wait_for_completition();
 public:
 

--- a/libraries/Storage/storage_common.h
+++ b/libraries/Storage/storage_common.h
@@ -7,8 +7,8 @@
 extern "C" {
 #endif
 
-//#define STORAGE_DEBUG
-//#define STORAGE_ASSERT
+#define STORAGE_DEBUG
+#define STORAGE_ASSERT
 
 /* -------------------------------------------------------------------------- */
 /*                                 STORAGE DEBUG                              */
@@ -61,7 +61,7 @@ static inline void rns_storage_dbg_mem(uint8_t *b, uint32_t _size)
 {
     if (b != nullptr) {
         Serial.println("");
-        for(int i = 0; i < _size; i++) {
+        for(uint32_t i = 0; i < _size; i++) {
             if(i != 0 && i % PRINT_SIZE == 0) {
                 if(i != 0)
                     Serial.println();


### PR DESCRIPTION
TestCodeFlash :+1: 
TestQSPI :+1: 
QSPIFormat :+1: 
QSPIReadPartitions :+1: 
FatFSOnQSPIFlash  :+1: 
LittleFSOn QSPIFlash :+1: 
TestSDCard :-1:  (also in released cores)