### PR TITLE
FreeRTOS restore original behaviour and allow override startup hooks

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -12,7 +12,7 @@ portenta_c33.build.fpu=-mfpu=fpv5-sp-d16
 portenta_c33.build.float-abi=-mfloat-abi=hard
 
 portenta_c33.build.board=PORTENTA_C33
-portenta_c33.build.defines=-DF_CPU=200000000 -DPROVIDE_FREERTOS_HOOK
+portenta_c33.build.defines=-DF_CPU=200000000
 portenta_c33.vid.0=0x2341
 portenta_c33.pid.0=0x0068
 portenta_c33.vid.1=0x2341

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -112,8 +112,8 @@ void arduino_main(void)
    Serial.begin(115200);
 #endif
    startAgt();
-   setup();
    start_freertos_on_header_inclusion();
+   setup();
    while (1)
    {
       loop();

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -64,6 +64,8 @@ void unsecure_registers() {
 #define str(s) #s
 
 extern "C" void Stacktrace_Handler(void);
+extern "C" __attribute__((weak)) void start_freertos_on_header_inclusion() {}
+extern "C" __attribute__((weak)) void early_start_freertos_on_header_inclusion() {}
 
 void arduino_main(void)
 {
@@ -111,7 +113,9 @@ void arduino_main(void)
    Serial.begin(115200);
 #endif
    startAgt();
+   early_start_freertos_on_header_inclusion();
    setup();
+   start_freertos_on_header_inclusion();
    while (1)
    {
       loop();

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -113,9 +113,7 @@ void arduino_main(void)
 #endif
    startAgt();
    setup();
-#ifdef PROVIDE_FREERTOS_HOOK
    start_freertos_on_header_inclusion();
-#endif
    while (1)
    {
       loop();

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -64,7 +64,6 @@ void unsecure_registers() {
 #define str(s) #s
 
 extern "C" void Stacktrace_Handler(void);
-extern "C" __attribute__((weak)) void start_freertos_on_header_inclusion() {}
 
 void arduino_main(void)
 {
@@ -112,7 +111,6 @@ void arduino_main(void)
    Serial.begin(115200);
 #endif
    startAgt();
-   start_freertos_on_header_inclusion();
    setup();
    while (1)
    {

--- a/libraries/Arduino_FreeRTOS/src/Arduino_FreeRTOS.h
+++ b/libraries/Arduino_FreeRTOS/src/Arduino_FreeRTOS.h
@@ -27,6 +27,27 @@ extern "C" {
 #include "lib/FreeRTOS-Kernel-v10.5.1/semphr.h"
 #include "lib/FreeRTOS-Kernel-v10.5.1/task.h"
 #include "lib/FreeRTOS-Kernel-v10.5.1/timers.h"
+#include <stdbool.h>
+
+
+// If you need to automatically start FREERTOS, declare either EARLY_AUTOSTART_FREERTOS or
+// AUTOSTART_FREERTOS in your library or sketch code (.ino or .cpp file)
+//
+// EARLY_AUTOSTART_FREERTOS -> if you need the scheduler to be already running in setup()
+// AUTOSTART_FREERTOS -> if you only declare the threads in setup() and use them in loop()
+
+void _start_freertos_on_header_inclusion_impl(bool early_start);
+void early_start_freertos_on_header_inclusion();
+void start_freertos_on_header_inclusion();
+#define EARLY_AUTOSTART_FREERTOS \
+    void early_start_freertos_on_header_inclusion() { \
+        _start_freertos_on_header_inclusion_impl(true); \
+    }
+#define AUTOSTART_FREERTOS \
+    void start_freertos_on_header_inclusion() { \
+        _start_freertos_on_header_inclusion_impl(false); \
+    }
+
 
 #ifdef __cplusplus
 }

--- a/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
+++ b/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
@@ -226,6 +226,7 @@ static void prvTaskExitError(void);
 #endif
 
 void loop_thread_func(void* arg) {
+    setup();
     while (1)
     {
         loop();

--- a/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
+++ b/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
@@ -225,7 +225,6 @@ static void prvTaskExitError(void);
 
 #endif
 
-#ifdef PROVIDE_FREERTOS_HOOK
 void loop_thread_func(void* arg) {
     while (1)
     {
@@ -246,7 +245,6 @@ void start_freertos_on_header_inclusion() {
 
     vTaskStartScheduler();
 }
-#endif
 
 /* Arduino specific overrides */
 void delay(uint32_t ms) {

--- a/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
+++ b/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
@@ -32,6 +32,7 @@
 #include "FreeRTOSConfig.h"
 #include "../../lib/FreeRTOS-Kernel-v10.5.1/FreeRTOS.h"
 #include "../../lib/FreeRTOS-Kernel-v10.5.1/task.h"
+#include "portmacro.h"
 
 #if BSP_TZ_NONSECURE_BUILD
  #include "tz_context.h"
@@ -224,6 +225,33 @@ static void prvPortStartFirstTask(void);
 static void prvTaskExitError(void);
 
 #endif
+
+
+static void sketch_thread_func(void* arg) {
+    bool early_start = (bool)arg;
+    if (early_start) {
+        setup();
+    }
+    while (1)
+    {
+        loop();
+    }
+}
+
+void _start_freertos_on_header_inclusion_impl(bool early_start) {
+    static TaskHandle_t sketch_task;
+    if (xTaskGetSchedulerState() != taskSCHEDULER_RUNNING) {
+        xTaskCreate(
+        (TaskFunction_t)sketch_thread_func,
+        "Sketch Thread",
+        4096 / 4,   /* usStackDepth in words */
+        (void*)early_start,   /* pvParameters */
+        4,         /* uxPriority */
+        &sketch_task /* pxCreatedTask */
+        );
+        vTaskStartScheduler();
+    }
+}
 
 /* Arduino specific overrides */
 void delay(uint32_t ms) {

--- a/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
+++ b/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
@@ -226,6 +226,8 @@ static void prvTaskExitError(void);
 
 #endif
 
+extern void setup(void);
+extern void loop(void);
 
 static void sketch_thread_func(void* arg) {
     bool early_start = (bool)arg;

--- a/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
+++ b/libraries/Arduino_FreeRTOS/src/portable/FSP/port.c
@@ -225,28 +225,6 @@ static void prvTaskExitError(void);
 
 #endif
 
-void loop_thread_func(void* arg) {
-    setup();
-    while (1)
-    {
-        loop();
-    }
-}
-
-static TaskHandle_t loop_task;
-void start_freertos_on_header_inclusion() {
-    xTaskCreate(
-      (TaskFunction_t)loop_thread_func,
-      "Loop Thread",
-      4096 / 4,   /* usStackDepth in words */
-      NULL,   /* pvParameters */
-      4,         /* uxPriority */
-      &loop_task /* pxCreatedTask */
-    );
-
-    vTaskStartScheduler();
-}
-
 /* Arduino specific overrides */
 void delay(uint32_t ms) {
     if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {


### PR DESCRIPTION
The default behaviour is do nothing: scheduler has to be started manually by the user.
Use `AUTOSTART_FREERTOS` if you declare tasks in your `setup()` and use them in `loop()`.
Use `EARLY_AUTOSTART_FREERTOS` if you need the scheduler to be already running in `setup()`.

Libraries that need to use threads/semaphores during `setup()` for example, to implement the usual

```
myObj.begin(); <- this starts a thread
while (!myObj) {  <- this becomes true when the thread is unlocked
  delay();
}
```

will need to declare `EARLY_START_FREERTOS_HOOK` in one of their cpp files

Also fixes https://github.com/arduino/ArduinoCore-renesas/pull/414#issuecomment-2601163077

/cc @hexnet1234 @gpb01 @Wetmelon 