### PR TITLE
WiFiS3 library: allow selection of WIFI_MODE_APSTA mode

### DIFF
--- a/libraries/WiFiS3/src/WiFi.cpp
+++ b/libraries/WiFiS3/src/WiFi.cpp
@@ -42,11 +42,11 @@ int CWifi::begin(const char* ssid) {
 }
 
 /* -------------------------------------------------------------------------- */
-int CWifi::begin(const char* ssid, const char *passphrase) {
+int CWifi::begin(const char* ssid, const char *passphrase, uint8_t mode) {
 /* -------------------------------------------------------------------------- */
    string res = "";
    modem.begin();
-   modem.write(string(PROMPT(_MODE)),res, "%s%d\r\n" , CMD_WRITE(_MODE), 1);
+   modem.write(string(PROMPT(_MODE)),res, "%s%d\r\n" , CMD_WRITE(_MODE), mode);
 
    if(passphrase == nullptr) {
       if(!modem.write(string(PROMPT(_BEGINSTA)),res, "%s%s\r\n" , CMD_WRITE(_BEGINSTA), ssid)) {
@@ -400,7 +400,7 @@ IPAddress CWifi::localIP() {
    IPAddress local_IP(0,0,0,0);
 
    if(modem.write(string(PROMPT(_MODE)),res, "%s" , CMD_READ(_MODE)))  {
-      if(atoi(res.c_str()) == 1) {
+      if(atoi(res.c_str()) == 1 || atoi(res.c_str()) == 3) {
          if(modem.write(string(PROMPT(_IPSTA)),res, "%s%d\r\n" , CMD_WRITE(_IPSTA), IP_ADDR)) {
             local_IP.fromString(res.c_str());
          }

--- a/libraries/WiFiS3/src/WiFi.h
+++ b/libraries/WiFiS3/src/WiFi.h
@@ -112,11 +112,12 @@ public:
     /* Start WiFi connection with passphrase
      * the most secure supported mode will be automatically selected
      *
-     * @param `ssid` Pointer to the SSID string.
-     * @param `passphrase` Passphrase. Valid characters in a passphrase
-     * must be between ASCII 32-126 (decimal).
+     * param ssid: Pointer to the SSID string.
+     * param passphrase: Passphrase. Valid characters in a passphrase
+     *        must be between ASCII 32-126 (decimal).
+     * param mode: WiFi mode: STA, AP or AP_STA (mixed) 
      */
-    int begin(const char* ssid, const char *passphrase);
+    int begin(const char* ssid, const char *passphrase, uint8_t mode = 1);
 
     /**
      * @brief Starts a Wi-Fi Access Point with the specified SSID.


### PR DESCRIPTION
I am developing a WebServer library that includes a WiFi manager. 
In the case of DHCP connections, it is essential to provide the user with the IP address assigned by the router.

In this situation (and in other scenarios), it is necessary to have the ability to operate in both WiFi Access Point mode and Station mode, simultaneously, after successfully connecting to the SSID.