### PR TITLE
Added end() function to Soft Serial - fix for #463 and #464

### DIFF
--- a/cores/arduino/FspLinkIrq.h
+++ b/cores/arduino/FspLinkIrq.h
@@ -16,6 +16,7 @@ typedef enum {
 
 extern int attachIrq2Link(uint32_t pin, PinStatus mode);
 extern int detachIrq2Link(pin_size_t pinNumber);
+extern int getIrqIndexFromPint(uint32_t pin);
 
 /* Wrapper class for FSP ELC 
     at the present only support the link of an external Irq to a peripheral */

--- a/cores/arduino/Interrupts.cpp
+++ b/cores/arduino/Interrupts.cpp
@@ -193,6 +193,21 @@ void attachInterrupt(pin_size_t pinNumber, voidFuncPtr func, PinStatus mode) {
     attachInterruptParam(pinNumber, (voidFuncPtrParam)func, mode, NULL);
 }
 
+
+int getIrqIndexFromPint(uint32_t pinNumber) {
+    CIrq *irq_context = nullptr;
+    int rv = -1;
+    int ch = pin2IrqChannel(pinNumber);
+    if(ch >= 0 && ch < MAX_IRQ_CHANNEL) {
+        irq_context = IrqChannel.get(ch,false);
+        if(irq_context != nullptr) {
+            rv = irq_context->cfg.irq;
+        }
+    }
+    return rv;   
+}
+
+
 int attachIrq2Link(uint32_t pinNumber, PinStatus mode) {
     CIrq *irq_context = nullptr;
     int ch = pin2IrqChannel(pinNumber);

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -70,6 +70,7 @@ class SoftwareSerial : public Stream, public arduino::Printable {
         ss_descr_t<2> rx_descr;
         uint8_t _tx_pin, _rx_pin;
         void rx_process();
+        bool initialized;
 
     public:
         using Print::write;
@@ -83,6 +84,7 @@ class SoftwareSerial : public Stream, public arduino::Printable {
         int peek();
         virtual size_t write(uint8_t byte);
         virtual int available();
+        virtual int end();
 };
 
 #endif  //__SOFTWARE_SERIAL_H__


### PR DESCRIPTION
This PR introduces the end() function to the Soft Serial library.
Using the end() function allows to use the pins allocated for the Soft Serial "manually" as GPIO. 
Soft Serial can be enabled again with a new call to begin().
This PR has been tested using Soft Serial pins as GPIO (so simple Digital Input or Digital Output).
Please note that when 2 pins are allocated to Soft Serial it is not allowed to change the function associated to these pins to "complex" configuration like PWM or PIN with Irq since the needed resources are taken by Soft Serial function.