### PR TITLE
Matrix: initialize _lastInterval when starting a sequence

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -219,6 +219,7 @@ public:
     void play(bool loop = false){
         _loop = loop;
         _sequenceDone = false;
+        _lastInterval = millis();
         next();
     }
     bool sequenceDone(){


### PR DESCRIPTION
The following sketch will display the first frame only for a few ms using core 1.4.1. Removing the delay(1200) from the sketch the first frame duration is correct. Initializing _lastInterval will make it work also with the delay.

```
#include "Arduino_LED_Matrix.h"

ArduinoLEDMatrix matrix;

const uint32_t snake[][4] = {
  { 0xffffffff, 0xffffffff, 0xffffffff, 1300 },
	{ 0x7fffffff, 0xffffffff, 0xfffff7ff, 66 },
	{ 0x3fe7ffff, 0xffffffff, 0xff7ff3fe, 66 },
	{ 0x1fc3fe7f, 0xfffffff7, 0xff3fe1fc, 66 },
	{ 0xf81fc3f, 0xe7ff7ff3, 0xfe1fc0f8, 66 },
	{ 0x500f81f, 0xc3fe3fe1, 0xfc0f8070, 66 },
	{ 0x500f, 0x81fc1fc0, 0xf8070020, 66 },
	{ 0x5, 0xf80f80, 0x70020000, 66 },
	{ 0x5, 0xa80880, 0x50020000, 600 },
	{ 0xd812, 0x41040880, 0x50020000, 200 },
	{ 0x5, 0xa80880, 0x50020000, 600 },
	{ 0xd812, 0x41040880, 0x50020000, 200 },
	
};
void setup() {
  Serial.begin(9600);
  while(!Serial){};

  matrix.begin();
  delay(1200);
  matrix.loadSequence(snake);
  matrix.play(true);
  Serial.println("start");

}

void loop() {
  // put your main code here, to run repeatedly:

}
```