### PR TITLE
USB: Remove DFU interface from Uno R4 WiFi

### DIFF
--- a/cores/arduino/usb/USB.cpp
+++ b/cores/arduino/usb/USB.cpp
@@ -31,8 +31,6 @@ extern "C" {
 #include "r_usb_basic_api.h"
 #include "r_usb_pcdc_api.h"
 
-#define USBD_ITF_CDC (0) // needs 2 interfaces
-
 #ifndef USBD_CDC_EP_CMD
 #define USBD_CDC_EP_CMD  (0x81)
 #endif
@@ -121,45 +119,73 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
 void __SetupUSBDescriptor() {
     if (!usbd_desc_cfg) {
 
-        uint8_t interface_count = (__USBInstallSerial ? 3 : 0) + (__USBGetHIDReport ? 1 : 0) + (__USBInstallMSD ? 1 : 0);
+        // This tracks the next (0 based) interface number to assign, incremented after each
+        // interface descriptor is created. After all interface descriptors have been created,
+        // it represents the (1 based) number of interface descriptors that have been defined.
+        uint8_t interface_count = 0;
 
-        uint8_t cdc_desc[TUD_CDC_DESC_LEN + TUD_DFU_RT_DESC_LEN] = {
+        /*
+         * -----    CDC
+         */
+        bool install_CDC = __USBInstallSerial;
+        uint8_t cdc_desc[TUD_CDC_DESC_LEN] = {
             // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-            TUD_CDC_DESCRIPTOR(USBD_ITF_CDC, USBD_STR_CDC, USBD_CDC_EP_CMD, USBD_CDC_CMD_MAX_SIZE, USBD_CDC_EP_OUT, USBD_CDC_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE),
-            TUD_DFU_RT_DESCRIPTOR(USBD_ITF_CDC+2, USBD_STR_DFU_RT, 0x0d, 1000, 4096),
+            TUD_CDC_DESCRIPTOR(interface_count, USBD_STR_CDC, USBD_CDC_EP_CMD, USBD_CDC_CMD_MAX_SIZE, USBD_CDC_EP_OUT, USBD_CDC_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE)
         };
+        interface_count += (install_CDC ? 2 : 0);
+
+        /*
+         * -----    DFU
+         */
+        bool install_DFU = false;
+#if CFG_TUD_DFU_RUNTIME
+        install_DFU = __USBInstallSerial;
+        uint8_t dfu_desc[TUD_DFU_RT_DESC_LEN] = {
+            // Interface number, string index, attribute, timeout, xfer size
+            TUD_DFU_RT_DESCRIPTOR(interface_count, USBD_STR_DFU_RT, 0x0d, 1000, 4096)
+        };
+        interface_count += (install_DFU ? 1 : 0);
+#else
+        uint8_t dfu_desc[0] = {};
+#endif
 
         /*
          * -----    HID
-         */ 
-
+         */
+        bool install_HID = false;
         size_t hid_report_len = 0;
         if (__USBGetHIDReport) {
+            install_HID = true;
             __USBGetHIDReport(&hid_report_len);
         }
-        uint8_t hid_itf = __USBInstallSerial ? 3 : 0;
         uint8_t hid_desc[TUD_HID_DESC_LEN] = {
             // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-            TUD_HID_DESCRIPTOR(hid_itf, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, USBD_HID_EP, CFG_TUD_HID_EP_BUFSIZE, 10)
+            TUD_HID_DESCRIPTOR(interface_count, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, USBD_HID_EP, CFG_TUD_HID_EP_BUFSIZE, 10)
         };
+        interface_count += (install_HID ? 1: 0);
 
         /*
          * -----    MASS STORAGE DEVICE
-         */ 
-
+         */
+        bool install_MSD = false;
 #if CFG_TUD_MSC
-        uint8_t msd_itf = (__USBInstallSerial ? 3 : 0) + (__USBGetHIDReport ? 1 : 0);
+        install_MSD = __USBInstallMSD;
         uint8_t msd_desc[TUD_MSC_DESC_LEN] = {
             // Interface number, string index, EP Out & EP In address, EP size
-            TUD_MSC_DESCRIPTOR(msd_itf, 0, USBD_MSD_EP_OUT, USBD_MSD_EP_IN, USBD_MSD_IN_OUT_SIZE)   
+            TUD_MSC_DESCRIPTOR(interface_count, 0, USBD_MSD_EP_OUT, USBD_MSD_EP_IN, USBD_MSD_IN_OUT_SIZE)   
         };
+        interface_count += (install_MSD ? 1 : 0);
 #else
         uint8_t msd_desc[0] = {};
 #endif
         
-
-        int usbd_desc_len = TUD_CONFIG_DESC_LEN + (__USBInstallSerial ? sizeof(cdc_desc) : 0) + (__USBGetHIDReport ? sizeof(hid_desc) : 0) + (__USBInstallMSD ? sizeof(msd_desc) : 0);
-
+        // Create configuration descriptor
+        int usbd_desc_len =
+            TUD_CONFIG_DESC_LEN
+            + (install_CDC ? sizeof(cdc_desc) : 0)
+            + (install_DFU ? sizeof(dfu_desc) : 0)
+            + (install_HID ? sizeof(hid_desc) : 0)
+            + (install_MSD ? sizeof(msd_desc) : 0);
         uint8_t tud_cfg_desc[TUD_CONFIG_DESC_LEN] = {
             // Config number, interface count, string index, total length, attribute, power in mA
             TUD_CONFIG_DESCRIPTOR(1, interface_count, USBD_STR_0, usbd_desc_len, TUSB_DESC_CONFIG_ATT_SELF_POWERED, 500)
@@ -172,15 +198,19 @@ void __SetupUSBDescriptor() {
             uint8_t *ptr = usbd_desc_cfg;
             memcpy(ptr, tud_cfg_desc, sizeof(tud_cfg_desc));
             ptr += sizeof(tud_cfg_desc);
-            if (__USBInstallSerial) {
+            if (install_CDC) {
                 memcpy(ptr, cdc_desc, sizeof(cdc_desc));
                 ptr += sizeof(cdc_desc);
             }
-            if (__USBGetHIDReport) {
+            if (install_DFU) {
+                memcpy(ptr, dfu_desc, sizeof(dfu_desc));
+                ptr += sizeof(dfu_desc);
+            }
+            if (install_HID) {
                 memcpy(ptr, hid_desc, sizeof(hid_desc));
                 ptr += sizeof(hid_desc);
             }
-            if (__USBInstallMSD) {
+            if (install_MSD) {
                 memcpy(ptr, msd_desc, sizeof(msd_desc));
                 ptr += sizeof(msd_desc);
             }

--- a/variants/UNOWIFIR4/tusb_config.h
+++ b/variants/UNOWIFIR4/tusb_config.h
@@ -80,7 +80,7 @@
 #define CFG_TUD_HID              1
 #define CFG_TUD_MIDI             0
 #define CFG_TUD_VENDOR           0
-#define CFG_TUD_DFU_RUNTIME      1
+#define CFG_TUD_DFU_RUNTIME      0
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE   ((TUD_OPT_HIGH_SPEED ? 512 : 64) * 4)


### PR DESCRIPTION
# Change motivation summary
The Uno R4 WiFi mistakenly presents a DFU port to its host when connected via USB.

# Change motivation details
When the Uno R4 WiFi is connected to a Windows host via USB cable, the Windows Device Manager app reveals that the device's DFU port is missing a driver. Attempting to install a driver via the Windows driver installer in this repository's ..\drivers folder does not resolve the issue. However, since the Uno R4 WiFi uploads applications via a COM port, not DFU, it should not be presenting a DFU port to the host at all.

# Resolution summary
* Modify the Uno R4 WiFi's variant specific header file (tusb_config.h) to disable `CFG_TUD_DFU_RUNTIME`.
* Modify the USB descriptor setup code (in USB.cpp) to respect the `CFG_TUD_DFU_RUNTIME` value in the header file.

# Resolution notes
I have altered how all of the USB interface descriptors are constructed to unify the approach used for each and improve the maintainability of the code. This expanded the scope of changes that were strictly required to address the issue, but I felt it made the entire method a bit easier to understand and manage going forward.

# Research supporting chosen resolution
Examination of the two files noted below leads me to believe that all board variants supported by this repository support DFU *except* the Uno R4 WiFi.

### DFU device driver installer INF (../drivers/renesas.inf)
* The PID for the Uno R4 WiFi device (0x006D) is not present in the DFU device driver installer INF file.
* The PID for all other board variants are present in the DFU device driver installer INF file, and have `CFG_TUD_DFU_RUNTIME` enabled in their variant specific header file.
### Arduino boards definition (../boards.txt)
1. All boards use dfu-util except Uno R4 WiFi, which uses bossac.

# Notes
* While I recognize that the ESP32-S3 used in the Uno R4 WiFi does in fact support DFU, I don't believe that people who are using that ability will be affected by this change. If I am incorrect on this point, let me know and I will review further.
* In addition to the Uno R4 WiFi, I also have an Uno R4 Minima. I tested its behavior with this PR - it continues to function using DFU as expected. I do not have any other devices to test with, so that is a potential gap that could be addressed prior to merging this PR.
* Pre-existing behavior when the `DISABLE_USB_SERIAL` macro is defined has been preserved. Specifically, when this macro is defined at compile time the device will not present either a DFU or a CDC interface to its host at runtime.
* This PR has the following effect on program memory usage for the following few devices I checked:
  * Uno R4 Minima: +168 bytes
  * Uno R4 WiFi: -200 bytes
  * Portenta C33: +208 bytes