### PR TITLE
fixed Arduino Nano R4 compile for CAN library

### DIFF
--- a/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
@@ -14,7 +14,7 @@
 
 #include "R7FA4M1_CAN.h"
 
-#if defined(ARDUINO_MINIMA) || defined(ARDUINO_UNOWIFIR4)
+#if defined(ARDUINO_MINIMA) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_NANO_R4)
 
 #include <IRQManager.h>
 

--- a/libraries/Arduino_CAN/src/R7FA4M1_CAN.h
+++ b/libraries/Arduino_CAN/src/R7FA4M1_CAN.h
@@ -17,7 +17,7 @@
 
 #include <Arduino.h>
 
-#if defined(ARDUINO_MINIMA) || defined(ARDUINO_UNOWIFIR4)
+#if defined(ARDUINO_MINIMA) || defined(ARDUINO_UNOWIFIR4) || defined(ARDUINO_NANO_R4)
 
 #include "api/HardwareCAN.h"
 


### PR DESCRIPTION
This should fix the #479 .

Discovered and tested by @okrim-dot during Make Tank activities.

