### PR TITLE
Update SPI stored setting also in begin()

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -139,6 +139,7 @@ void ArduinoSPI::begin()
   _sci_spi_ext_cfg.clk_div.mddr = 0;
 
   configSpiSettings(DEFAULT_SPI_SETTINGS);
+  _settings = DEFAULT_SPI_SETTINGS;
 
   /* Configure the Interrupt Controller. */
   if (_is_sci)


### PR DESCRIPTION
This PR solves #493.
The SPI settings were not updated in the strange context of the issue because the begin() function did update SPI setting without storing the values into the stored SPI settings (stored SPI settings are used to avoid the update of the settings in case new setting are the same of the ones already used).  