### PR TITLE
Initialize private variables in Arduino_LED_Matrix.h

### DIFF
--- a/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
+++ b/libraries/Arduino_LED_Matrix/src/Arduino_LED_Matrix.h
@@ -333,15 +333,15 @@ public:
 
 private:
     int _currentFrame = 0;
-    uint32_t _frameHolder[3];
-    uint32_t* _frames;
-    uint32_t _framesCount;
+    uint32_t _frameHolder[3] = {0, 0, 0};
+    uint32_t* _frames = nullptr;
+    uint32_t _framesCount = 0;
     uint32_t _interval = 0;
     uint32_t _lastInterval = 0;
     bool _loop = false;
     FspTimer _ledTimer;
     bool _sequenceDone = false;
-    voidFuncPtr _callBack;
+    voidFuncPtr _callBack = nullptr;
 
     static void turnOnLedISR(timer_callback_args_t *arg) {
         static volatile int i_isr = 0;


### PR DESCRIPTION
Fixes #498 

This PR initializes the previously uninitialized variables in order to resolve runtime errors due to an invalid pointer when using the LED matrix on the Arduino R4 WiFi.