### PR TITLE
Fix CI warning by removing set-output command

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Check if API should be compiled in the core
         id: checkapi
         run: |
-          if [[ $(grep -r api platform.txt) ]]; then echo "::set-output name=IS_API::true"; fi
+          if [[ $(grep -r api platform.txt) ]]; then echo "IS_API=true" >> $GITHUB_OUTPUT; fi
 
       - name: Install ArduinoCore-API
         run: rm "$GITHUB_WORKSPACE/cores/arduino/api" && mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"


### PR DESCRIPTION
This PR is to fix some warnings which I noticed in the CI jobs "compile-test":
<img width="1192" height="202" alt="image" src="https://github.com/user-attachments/assets/a1af3e37-e511-4117-818c-bd75c6e757ec" />

The fix is straight-forward and described in the link given in the warning: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

All occurrences of 
```
- name: Set output
run: echo "::set-output name={name}::{value}"
```
should be replaced by
```
- name: Set output
run: echo "{name}={value}" >> $GITHUB_OUTPUT
```

The other deprecated command is `save-state`, which is not used here.