### PR TITLE
Changed CFG_TUH_HID define to value 2

### DIFF
--- a/variants/PORTENTA_C33/tusb_config.h
+++ b/variants/PORTENTA_C33/tusb_config.h
@@ -103,7 +103,7 @@
 
 #define CFG_TUH_MSC              1
 #define CFG_TUH_HUB              1
-#define CFG_TUH_HID              1
+#define CFG_TUH_HID              2
 #define CFG_TUH_DEVICE_MAX       (3*CFG_TUH_HUB)
 #define CFG_TUH_ENDPOINT_MAX     8
 #define CFG_TUH_API_EDPT_XFER    1


### PR DESCRIPTION
This change allows the library control over two simultaneously connected USB devices instead of just one; Critical for some USB HID Host library examples like the "Keyboard And Mouse" example.