### PR TITLE
Fix can disconnected issue #514

### DIFF
--- a/libraries/Arduino_CAN/src/R7FA6M5_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA6M5_CAN.cpp
@@ -74,7 +74,7 @@ R7FA6M5_CAN::R7FA6M5_CAN(int const can_tx_pin, int const can_rx_pin)
   .p_afl              = nullptr,
   //.txmb_txi_enable    = ((1ULL << 9) | (1ULL << 0) | 0ULL),
   .txmb_txi_enable    = 0xFFFFFFFFFFFFFFFF,
-  .error_interrupts   = (R_CANFD_CFDC_CTR_EWIE_Msk | R_CANFD_CFDC_CTR_EPIE_Msk | R_CANFD_CFDC_CTR_BOEIE_Msk | R_CANFD_CFDC_CTR_BORIE_Msk | R_CANFD_CFDC_CTR_OLIE_Msk | 0U),
+  .error_interrupts   = 0U,
   .p_data_timing      = nullptr,
   .delay_compensation = (1),
   .p_global_cfg       = &_canfd_global_cfg,


### PR DESCRIPTION
This PR disable the error interrupt conditions for canfd, it aims to fix issue #514.
When interrupt conditions are enabled the error isr is continuously firing preventing the application to run: in particular when the CAN is completely disconnected it seems that application is completely frozen, while instead it is continuously handling the same error isr.
Disabling the error conditions is the simplest way to avoid that: the write function will detect problems and returns error, giving the application the possibility to run.
With this change it has been observed that occasionally the write function does not return an error when the CAN bus is disconnected. This seems to be an acceptable compromise. 
 