### PR TITLE
fix Rx edge sensitivity to recover from framing error / BREAK

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -241,7 +241,14 @@ int SoftwareSerial::begin(uint32_t baudrate, uint32_t sconfig, bool inverted)
        indexes in the NVIC */
     int irq_index = getIrqIndexFromPin(_rx_pin);
     if(irq_index == -1) {
-        rx_descr.irq_chan = attachIrq2Link(_rx_pin, CHANGE); // Enable RX pin IRQ.
+        if (inverted == false)
+        {
+            rx_descr.irq_chan = attachIrq2Link(_rx_pin, FALLING); // Enable RX pin IRQ on falling edge (normal polarity).
+        }
+        else
+        {
+            rx_descr.irq_chan = attachIrq2Link(_rx_pin, RISING);  // Enable RX pin IRQ on rising edge (inverted polarity).
+        }
     } else {
         R_BSP_IrqEnable ((IRQn_Type)irq_index);
     }


### PR DESCRIPTION
I maintain an [Arduino library for LIN master emulation](https://github.com/gicking/LIN_master_portable_Arduino). A LIN frame starts with a BREAK signal (>13b low). 

With the original SoftwareSerial implementation I was unable to receive anything after BREAK. On deeper analysis I found that the selected Rx-IRQ edge sensitivity (CHANGING) interprets the rising edge of the BREAK as the start bit for the next byte (see screenshot), which leads to loss of sync.

<img width="769" height="187" alt="grafik" src="https://github.com/user-attachments/assets/58507d02-ddd4-483a-bf48-a3417ada8c38" />

However, when I change the Rx edge sensitivity to only falling (or rising for inverted logic), the issue disappears and I can receive the complete frame without hassle :-)

To verify this fix I checked the Rx reception after a BREAK (aka FE) using the below sketch. Here are the logs for [original](https://github.com/user-attachments/files/25077608/original.log) (all fail) and [fix](https://github.com/user-attachments/files/25077607/fix.log) (all ok)

```
/*
  check SoftwareSerial bugfix for framing errors

  Setup: 
    - connect Tx1 with Rx
    - check console output
*/

#include <SoftwareSerial.h>

SoftwareSerial SoftSerial(2, 7); // Rx, Tx

void setup() {
  Serial1.begin(19200);       // HW-Serial / sender
  SoftSerial.begin(19200);    // SW-Serial / receiver
  Serial.begin(115200);       // console output
  delay(5000);                // allow terminal to connect to VCP
}

void loop() {

  static uint8_t Tx=0x00, Rx[2];

  // flush Rx buffer, just to be sure
  while (SoftSerial.available())
    SoftSerial.read();

  // send BREAK / provoke Rx framing error
  Serial1.begin(9600);
  Serial1.write((uint8_t) 0x00);
  Serial1.begin(19200);
  
  // send byte
  Serial1.write((uint8_t) Tx);

  // read loop-back (BREAK + byte)
  while (SoftSerial.available() < 2);
  SoftSerial.readBytes(Rx, 2);

  // check received bytes
  Serial.print("Tx: 0x00 0x");
  Serial.print(Tx, HEX);
  Serial.print(", Rx: 0x");
  Serial.print((int) Rx[0], HEX);
  Serial.print(", 0x");
  Serial.print((int) Rx[1], HEX);

  if ((Rx[0] == 0x00) && (Rx[1] == Tx))
    Serial.println(" -> ok");
  else
    Serial.println(" -> FAIL");

  // test 0x00..0xFF
  Tx++;
  if (Tx == 0x00)
    while(1);

  delay(50);
}

```
