### PR TITLE
Increase I2C timeout to ensure compatibility with LCD oled displays

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -191,7 +191,7 @@ TwoWire::TwoWire(int scl, int sda, WireAddressMode_t am /*= ADDRESS_MODE_7_BITS*
   is_master(true),
   is_sci(false),
   address_mode(am),
-  timeout_us(1000),
+  timeout_us(WIRE_DEFAULT_TIMEOUT_US),
   transmission_begun(false),
   data_too_long(false),
   rx_index(0),

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -33,6 +33,8 @@
 #include "r_i2c_master_api.h"
 #include "r_i2c_slave_api.h"
 
+#define WIRE_DEFAULT_TIMEOUT_US  (100000)
+
 extern "C" {
   void i2c_callback(i2c_master_callback_args_t *p_args);
 }
@@ -124,7 +126,7 @@ class TwoWire : public arduino::HardwareI2C {
     void onRequest( void (*)(void) );
 
     void setBusStatus(WireStatus_t);
-    /* set timeout in us for I2C communication (default is 1000 us) 
+    /* set timeout in us for I2C communication
        the second parameter has been added for compatibility but it has no effect
 
        Please note: on uno R4 (both minima and wifi) the timeout has only effect
@@ -133,7 +135,7 @@ class TwoWire : public arduino::HardwareI2C {
        On Portenta C33 however timeout is used in both cases (with or without
        I2C pull up) because at low level the NACK does not immediately stop the I2C
        communication. */
-    void setWireTimeout(unsigned int _timeout_us = 1000, bool reset_on_timeout = false);
+    void setWireTimeout(unsigned int _timeout_us = WIRE_DEFAULT_TIMEOUT_US, bool reset_on_timeout = false);
 
     inline size_t write(unsigned long n) { return write((uint8_t)n); }
     inline size_t write(long n) { return write((uint8_t)n); }


### PR DESCRIPTION
This PR increase the default timeout of Wire to 100 ms.
This solves the problem #520 due to the fact that a reduced timeout made some small LCD oled displays to fails.
However due to this change the waiting time for an I2C scan is increased to around 12 seconds changing the behavior expected by the issue #492.