### PR TITLE
bootloader: changed description to use new bootloader script

### DIFF
--- a/bootloaders/UNO_R4/README.md
+++ b/bootloaders/UNO_R4/README.md
@@ -1,6 +1,33 @@
 :floppy_disk: `bootloaders/UNO_R4`
 ====================================
-Compiled with
+# To compile bootloader:
+
+Download this file (https://github.com/arduino/arduino-renesas-bootloader/blob/main/compile-bootloader.sh)
+using either:
+```bash
+curl -O https://raw.githubusercontent.com/arduino/arduino-renesas-bootloader/refs/heads/main/compile-bootloader.sh
+```
+or
+```bash
+wget https://raw.githubusercontent.com/arduino/arduino-renesas-bootloader/refs/heads/main/compile-bootloader.sh
+```
+Ensure that `compile-bootloader.sh` is executable.
+If it is not run: `chmod +x compile-bootloader.sh`
+Launch the script:
+```bash
+./compile-bootloader.sh R4-wifi
+```
+for Uno R4 Wifi bootloader or 
+```bash
+./compile-bootloader.sh R4-minima
+```
+for Uno R4 Minima
+and follow the script instructions.
+
+
+# Old instructions:
+
+Bootloader was compiled with (Old compiling instructions *** DEPRECATED ***)
 ```bash
 git clone https://github.com/arduino/arduino-renesas-bootloader
 git clone https://github.com/hathach/tinyusb


### PR DESCRIPTION
This PR is related to PR Build process improvement and bug fixing #9 of [arduino-renesas-bootloader](https://github.com/arduino/arduino-renesas-bootloader) and changes the description of the bootloader to use new script to build the bootloader. 
To be merged after the other one.