### PR TITLE
se05x: added library stub definition

### DIFF
--- a/libraries/stubs/SE05X.h
+++ b/libraries/stubs/SE05X.h
@@ -1,0 +1,7 @@
+/*
+  Copyright (C) Arduino s.r.l. and/or its affiliated companies
+  SPDX-License-Identifier: MPL-2.0
+*/
+
+// SE05X library has been moved to https://github.com/arduino-libraries/Arduino_SE05X
+#error "Please install Arduino_SE05X from Library Manager"


### PR DESCRIPTION
with this definition we can instruct the user to use the library present in the library manager, since the one present in the core is removed.

This PR has to be merged after https://github.com/arduino/ArduinoCore-renesas/pull/539 and https://github.com/arduino-libraries/Arduino_SE05X/pull/6