### PR TITLE
SPI: Prevent SPI.end() from hanging before initialization

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -166,6 +166,9 @@ void ArduinoSPI::begin()
 
 void ArduinoSPI::end()
 {
+  if (!_is_initialized) {
+    return;
+  }
   if (_is_sci) {
     _close(&_spi_sci_ctrl);
   } else {


### PR DESCRIPTION
Calling `SPI.end()` before `SPI.begin()` causes the board to become unresponsive.

`ArduinoSPI::end()` calls the `_close` function pointer even when SPI has not been initialized. The `_close` pointer is assigned during `SPI.begin()`, so it is not valid before initialization.

This change makes `ArduinoSPI::end()` return early when `_is_initialized` is `false`.

Fixes: #552 
